### PR TITLE
Render addon descriptions with new bbcode crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,12 +731,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bbcode-tagger"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d232687d86c4ff15aceb45cda3f8f5050110b12268f86b29b60e46142fa0a7"
+name = "bbcode"
+version = "0.1.0"
+
+[[package]]
+name = "bbcode-egui"
+version = "0.1.0"
 dependencies = [
- "regex",
+ "bbcode",
+ "egui",
+ "egui_extras",
 ]
 
 [[package]]
@@ -1935,6 +1939,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 name = "eso-addon-manager"
 version = "0.4.19"
 dependencies = [
+ "bbcode-egui",
  "dotenv",
  "eframe",
  "egui_extras",
@@ -1955,7 +1960,6 @@ dependencies = [
 name = "eso-addons-core"
 version = "0.1.2"
 dependencies = [
- "bbcode-tagger",
  "chrono",
  "colored",
  "dirs",
@@ -6432,6 +6436,17 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tools"
+version = "0.1.0"
+dependencies = [
+ "bbcode",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ panic = 'abort'   # Abort on panic
 strip = true      # Strip symbols from binary*
 
 [workspace]
-members = [".", "core", "entity", "migration"]
+members = [".", "bbcode", "bbcode-egui", "core", "entity", "migration", "tools"]
 
 [[bin]]
 name = "eso-addon-manager"
@@ -31,6 +31,7 @@ args = [
 [dependencies]
 eframe = "0.33.3"
 tokio = { version = "1.51.1", features = ["full"] }
+bbcode-egui = { path = "./bbcode-egui", version = "0.1", features = ["entities"] }
 eso-addons-core = { version = "0.1.2", path = "./core" }
 strum = "0.28.0"
 strum_macros = "0.28.0"

--- a/bbcode-egui/Cargo.toml
+++ b/bbcode-egui/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bbcode-egui"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Render bbcode AST into egui"
+
+[features]
+entities = []
+
+[dependencies]
+bbcode = { path = "../bbcode", version = "0.1" }
+egui = "0.33.3"
+egui_extras = { version = "0.33.3", features = ["all_loaders"] }

--- a/bbcode-egui/src/decode.rs
+++ b/bbcode-egui/src/decode.rs
@@ -1,0 +1,214 @@
+//! Decode HTML numeric and named entities and strip control / bidi
+//! formatting characters. Active only when the `entities` feature is on;
+//! otherwise [`decode`] returns its input unchanged.
+
+use std::borrow::Cow;
+
+#[cfg(feature = "entities")]
+pub fn decode(s: &str) -> Cow<'_, str> {
+    if !needs_decode(s) {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < s.len() {
+        if bytes[i] == b'&'
+            && let Some((ch, consumed)) = parse_entity(&s[i..])
+        {
+            if !is_dangerous(ch) {
+                out.push(ch);
+            }
+            i += consumed;
+            continue;
+        }
+        let ch = s[i..]
+            .chars()
+            .next()
+            .expect("non-empty slice has a char");
+        if !is_dangerous(ch) {
+            out.push(ch);
+        }
+        i += ch.len_utf8();
+    }
+    Cow::Owned(out)
+}
+
+#[cfg(not(feature = "entities"))]
+pub fn decode(s: &str) -> Cow<'_, str> {
+    Cow::Borrowed(s)
+}
+
+#[cfg(feature = "entities")]
+fn needs_decode(s: &str) -> bool {
+    let mut has_high = false;
+    for &b in s.as_bytes() {
+        if b == b'&' {
+            return true;
+        }
+        if b < 0x20 && b != b'\t' && b != b'\n' && b != b'\r' {
+            return true;
+        }
+        if b == 0x7F {
+            return true;
+        }
+        if b >= 0x80 {
+            has_high = true;
+        }
+    }
+    has_high && s.chars().any(is_dangerous)
+}
+
+#[cfg(feature = "entities")]
+fn is_dangerous(c: char) -> bool {
+    let n = c as u32;
+    if n < 0x20 && c != '\t' && c != '\n' && c != '\r' {
+        return true;
+    }
+    if n == 0x7F {
+        return true;
+    }
+    if (0x80..=0x9F).contains(&n) {
+        return true;
+    }
+    if (0x202A..=0x202E).contains(&n) {
+        return true;
+    }
+    if (0x2066..=0x2069).contains(&n) {
+        return true;
+    }
+    if n == 0xFEFF {
+        return true;
+    }
+    if (0xE0000..=0xE007F).contains(&n) {
+        return true;
+    }
+    false
+}
+
+#[cfg(feature = "entities")]
+fn parse_entity(s: &str) -> Option<(char, usize)> {
+    let bytes = s.as_bytes();
+    if bytes.len() < 4 {
+        return None;
+    }
+    if bytes[1] == b'#' {
+        let (radix, start) = if bytes.len() > 2 && (bytes[2] == b'x' || bytes[2] == b'X') {
+            (16, 3)
+        } else {
+            (10, 2)
+        };
+        let max_end = (start + 8).min(bytes.len());
+        for end in start..max_end {
+            if bytes[end] == b';' {
+                if end == start {
+                    return None;
+                }
+                let body = &s[start..end];
+                let n = u32::from_str_radix(body, radix).ok()?;
+                let ch = char::from_u32(n)?;
+                return Some((ch, end + 1));
+            }
+        }
+        return None;
+    }
+    static NAMED: &[(&[u8], char)] = &[
+        (b"amp;", '&'),
+        (b"lt;", '<'),
+        (b"gt;", '>'),
+        (b"quot;", '"'),
+        (b"apos;", '\''),
+        (b"nbsp;", '\u{00A0}'),
+    ];
+    let rest = &bytes[1..];
+    for (name, ch) in NAMED {
+        if rest.starts_with(name) {
+            return Some((*ch, 1 + name.len()));
+        }
+    }
+    None
+}
+
+#[cfg(all(test, feature = "entities"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passthrough_when_safe() {
+        assert!(matches!(decode("hello world"), Cow::Borrowed(_)));
+        assert!(matches!(decode("привет мир"), Cow::Borrowed(_)));
+        assert!(matches!(decode(""), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn decimal_entity() {
+        assert_eq!(decode("&#1056;"), "Р");
+        assert_eq!(decode("&#65;"), "A");
+    }
+
+    #[test]
+    fn hex_entity() {
+        assert_eq!(decode("&#x420;"), "Р");
+        assert_eq!(decode("&#X420;"), "Р");
+    }
+
+    #[test]
+    fn named_entities() {
+        assert_eq!(decode("&amp;&lt;&gt;&quot;&apos;"), "&<>\"'");
+        assert_eq!(decode("a&nbsp;b"), "a\u{00A0}b");
+    }
+
+    #[test]
+    fn unknown_entity_kept_as_literal() {
+        assert_eq!(decode("&copy;"), "&copy;");
+        assert_eq!(decode("&"), "&");
+        assert_eq!(decode("a & b"), "a & b");
+    }
+
+    #[test]
+    fn malformed_numeric_kept_as_literal() {
+        assert_eq!(decode("&#xyz;"), "&#xyz;");
+        assert_eq!(decode("&#;"), "&#;");
+        assert_eq!(decode("&#x;"), "&#x;");
+    }
+
+    #[test]
+    fn surrogate_kept_as_literal() {
+        assert_eq!(decode("&#xD800;"), "&#xD800;");
+    }
+
+    #[test]
+    fn control_chars_stripped() {
+        assert_eq!(decode("a\u{0001}b"), "ab");
+        assert_eq!(decode("&#1;"), "");
+        assert_eq!(decode("a\u{007F}b"), "ab");
+    }
+
+    #[test]
+    fn bidi_stripped() {
+        assert_eq!(decode("a\u{202E}b"), "ab");
+        assert_eq!(decode("a&#x202E;b"), "ab");
+        assert_eq!(decode("a\u{2068}b"), "ab");
+    }
+
+    #[test]
+    fn tag_chars_stripped() {
+        assert_eq!(decode("a\u{E0041}b"), "ab");
+    }
+
+    #[test]
+    fn whitespace_preserved() {
+        assert_eq!(decode("a\tb\nc\rd"), "a\tb\nc\rd");
+    }
+
+    #[test]
+    fn zwj_preserved() {
+        assert_eq!(decode("a\u{200D}b"), "a\u{200D}b");
+    }
+
+    #[test]
+    fn bandits_sample() {
+        let s = "&#1054;&#1087;&#1080;&#1089;&#1072;&#1085;&#1080;&#1077;";
+        assert_eq!(decode(s), "Описание");
+    }
+}

--- a/bbcode-egui/src/ir.rs
+++ b/bbcode-egui/src/ir.rs
@@ -1,0 +1,361 @@
+use bbcode::{Element, Node};
+
+use crate::decode::decode;
+use crate::sanitize::{parse_color, sanitize_image_url, sanitize_url, sanitize_youtube_id};
+use crate::style::{Style, size_from_attr};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HAlign {
+    Left,
+    Center,
+    Right,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HiddenKind {
+    Spoiler,
+    Blur,
+}
+
+#[derive(Debug)]
+pub enum Block {
+    Para(Vec<Inline>),
+    List {
+        ordered: bool,
+        items: Vec<Vec<Block>>,
+    },
+    Indent(Vec<Block>),
+    Code(String),
+    Hidden(HiddenKind, Vec<Block>),
+    Quote(Vec<Block>),
+    Align(HAlign, Vec<Block>),
+}
+
+#[derive(Debug)]
+pub enum Inline {
+    Text { text: String, style: Style },
+    Link { label: Vec<Inline>, url: String },
+    Image(String),
+    Youtube(String),
+}
+
+pub fn build_blocks(nodes: &[Node<'_>], style: &Style) -> Vec<Block> {
+    let mut blocks: Vec<Block> = Vec::new();
+    let mut inline: Vec<Inline> = Vec::new();
+    for node in nodes {
+        emit_node(node, style, &mut blocks, &mut inline);
+    }
+    flush_para(&mut inline, &mut blocks);
+    blocks
+}
+
+fn emit_node(
+    node: &Node<'_>,
+    style: &Style,
+    blocks: &mut Vec<Block>,
+    inline: &mut Vec<Inline>,
+) {
+    match node {
+        Node::Text(s) => inline.push(Inline::Text {
+            text: decode(s).into_owned(),
+            style: style.clone(),
+        }),
+        Node::Element(e) => emit_element(e, style, blocks, inline),
+    }
+}
+
+fn emit_element(
+    e: &Element<'_>,
+    style: &Style,
+    blocks: &mut Vec<Block>,
+    inline: &mut Vec<Inline>,
+) {
+    let tag = e.tag.to_ascii_lowercase();
+    match tag.as_str() {
+        "b" => emit_inline_styled(e, style, |s| s.bold = true, blocks, inline),
+        "i" => emit_inline_styled(e, style, |s| s.italic = true, blocks, inline),
+        "u" => emit_inline_styled(e, style, |s| s.underline = true, blocks, inline),
+        "s" | "strike" => emit_inline_styled(e, style, |s| s.strike = true, blocks, inline),
+        "color" => {
+            let mut s = style.clone();
+            if let Some(c) = e.attr.and_then(parse_color) {
+                s.color = Some(c);
+            }
+            emit_children_inline(e, &s, blocks, inline);
+        }
+        "size" => {
+            let mut s = style.clone();
+            if let Some(size) = size_from_attr(e.attr, style.size_pt) {
+                s.size_pt = size;
+            }
+            emit_children_inline(e, &s, blocks, inline);
+        }
+        "font" => emit_children_inline(e, style, blocks, inline),
+
+        "url" => emit_url(e, style, inline, false),
+        "email" => emit_url(e, style, inline, true),
+        "img" => emit_image(e, inline),
+        "youtube" => emit_youtube(e, inline),
+
+        "list" | "ul" | "ol" => {
+            flush_para(inline, blocks);
+            let ordered = tag == "ol"
+                || matches!(e.attr_value(), Some(v) if !v.is_empty() && v != "*");
+            let mut items: Vec<Vec<Block>> = Vec::new();
+            for child in &e.children {
+                if let Node::Element(item) = child
+                    && (item.tag == "*" || item.is("li"))
+                {
+                    items.push(build_blocks(&item.children, style));
+                }
+            }
+            blocks.push(Block::List { ordered, items });
+        }
+        "*" | "li" => emit_passthrough(e, style, blocks, inline),
+
+        "indent" => {
+            flush_para(inline, blocks);
+            blocks.push(Block::Indent(build_blocks(&e.children, style)));
+        }
+        "code" | "highlight" | "pre" => {
+            flush_para(inline, blocks);
+            blocks.push(Block::Code(collect_text(&e.children)));
+        }
+        "spoiler" => {
+            flush_para(inline, blocks);
+            blocks.push(Block::Hidden(
+                HiddenKind::Spoiler,
+                build_blocks(&e.children, style),
+            ));
+        }
+        "blur" => {
+            flush_para(inline, blocks);
+            blocks.push(Block::Hidden(
+                HiddenKind::Blur,
+                build_blocks(&e.children, style),
+            ));
+        }
+        "quote" => {
+            flush_para(inline, blocks);
+            blocks.push(Block::Quote(build_blocks(&e.children, style)));
+        }
+        "center" => {
+            flush_para(inline, blocks);
+            blocks.push(Block::Align(HAlign::Center, build_blocks(&e.children, style)));
+        }
+        "left" => {
+            flush_para(inline, blocks);
+            blocks.push(Block::Align(HAlign::Left, build_blocks(&e.children, style)));
+        }
+        "right" => {
+            flush_para(inline, blocks);
+            blocks.push(Block::Align(HAlign::Right, build_blocks(&e.children, style)));
+        }
+        _ => emit_passthrough(e, style, blocks, inline),
+    }
+}
+
+fn emit_inline_styled(
+    e: &Element<'_>,
+    style: &Style,
+    apply: impl FnOnce(&mut Style),
+    blocks: &mut Vec<Block>,
+    inline: &mut Vec<Inline>,
+) {
+    let mut s = style.clone();
+    apply(&mut s);
+    emit_children_inline(e, &s, blocks, inline);
+}
+
+fn emit_children_inline(
+    e: &Element<'_>,
+    style: &Style,
+    blocks: &mut Vec<Block>,
+    inline: &mut Vec<Inline>,
+) {
+    for child in &e.children {
+        emit_node(child, style, blocks, inline);
+    }
+}
+
+fn emit_passthrough(
+    e: &Element<'_>,
+    style: &Style,
+    blocks: &mut Vec<Block>,
+    inline: &mut Vec<Inline>,
+) {
+    inline.push(Inline::Text {
+        text: e.raw_open.to_string(),
+        style: style.clone(),
+    });
+    for child in &e.children {
+        emit_node(child, style, blocks, inline);
+    }
+}
+
+fn resolve_link(s: &str, email: bool) -> Option<String> {
+    if email {
+        sanitize_email(s)
+    } else {
+        sanitize_url(s)
+    }
+}
+
+fn emit_url(e: &Element<'_>, style: &Style, inline: &mut Vec<Inline>, email: bool) {
+    let url = e.attr.and_then(|a| resolve_link(&decode(a), email)).or_else(|| {
+        if let [Node::Text(t)] = e.children.as_slice() {
+            resolve_link(&decode(t), email)
+        } else {
+            None
+        }
+    });
+    let Some(url) = url else {
+        inline.push(Inline::Text {
+            text: e.raw_open.to_string(),
+            style: style.clone(),
+        });
+        for child in &e.children {
+            collect_inline(child, style, inline);
+        }
+        return;
+    };
+    let mut label_inlines: Vec<Inline> = Vec::new();
+    let label_is_url_only = e.children.is_empty()
+        || (e.children.len() == 1
+            && matches!(&e.children[0], Node::Text(t) if resolve_link(&decode(t), email).is_some()));
+    if label_is_url_only {
+        let display: String = if email {
+            url.strip_prefix("mailto:").unwrap_or(&url).to_string()
+        } else {
+            url.clone()
+        };
+        label_inlines.push(Inline::Text {
+            text: display,
+            style: style.clone(),
+        });
+    } else {
+        for child in &e.children {
+            collect_inline(child, style, &mut label_inlines);
+        }
+    }
+    inline.push(Inline::Link {
+        label: label_inlines,
+        url,
+    });
+}
+
+fn sanitize_email(raw: &str) -> Option<String> {
+    let s = bbcode::unquote(raw).trim();
+    if s.is_empty() {
+        return None;
+    }
+    if let Some(rest) = s.strip_prefix("mailto:") {
+        return is_email_addr(rest).then(|| format!("mailto:{rest}"));
+    }
+    is_email_addr(s).then(|| format!("mailto:{s}"))
+}
+
+fn is_email_addr(s: &str) -> bool {
+    let mut parts = s.splitn(2, '@');
+    let local = parts.next().unwrap_or("");
+    let domain = parts.next().unwrap_or("");
+    !local.is_empty()
+        && !domain.is_empty()
+        && domain.contains('.')
+        && !s.chars().any(|c| c.is_whitespace())
+}
+
+fn emit_image(e: &Element<'_>, inline: &mut Vec<Inline>) {
+    let url = collect_text(&e.children);
+    if let Some(u) = sanitize_image_url(&url) {
+        inline.push(Inline::Image(u));
+    } else {
+        inline.push(Inline::Text {
+            text: e.raw_open.to_string(),
+            style: Style::default(),
+        });
+    }
+}
+
+fn emit_youtube(e: &Element<'_>, inline: &mut Vec<Inline>) {
+    let id = collect_text(&e.children);
+    if let Some(id) = sanitize_youtube_id(id.trim()) {
+        inline.push(Inline::Youtube(id));
+    } else {
+        inline.push(Inline::Text {
+            text: e.raw_open.to_string(),
+            style: Style::default(),
+        });
+    }
+}
+
+fn collect_inline(node: &Node<'_>, style: &Style, out: &mut Vec<Inline>) {
+    match node {
+        Node::Text(s) => out.push(Inline::Text {
+            text: decode(s).into_owned(),
+            style: style.clone(),
+        }),
+        Node::Element(e) => {
+            let mut blocks: Vec<Block> = Vec::new();
+            emit_element(e, style, &mut blocks, out);
+        }
+    }
+}
+
+fn collect_text(nodes: &[Node<'_>]) -> String {
+    if let [Node::Text(s)] = nodes {
+        return decode(s).into_owned();
+    }
+    let mut s = String::new();
+    for n in nodes {
+        flatten_text(n, &mut s);
+    }
+    decode(&s).into_owned()
+}
+
+fn flatten_text(node: &Node<'_>, out: &mut String) {
+    match node {
+        Node::Text(s) => out.push_str(s),
+        Node::Element(e) => {
+            for c in &e.children {
+                flatten_text(c, out);
+            }
+        }
+    }
+}
+
+fn flush_para(inline: &mut Vec<Inline>, blocks: &mut Vec<Block>) {
+    if inline.is_empty() {
+        return;
+    }
+    let para = std::mem::take(inline);
+    blocks.push(Block::Para(para));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn email_addr_validation() {
+        assert!(is_email_addr("a@b.c"));
+        assert!(!is_email_addr("a@b"));
+        assert!(!is_email_addr("@b.c"));
+        assert!(!is_email_addr("a@"));
+        assert!(!is_email_addr("a b@c.d"));
+    }
+
+    #[test]
+    fn email_sanitize_prefixes_mailto() {
+        assert_eq!(
+            sanitize_email("user@example.com"),
+            Some("mailto:user@example.com".to_string())
+        );
+        assert_eq!(
+            sanitize_email("mailto:user@example.com"),
+            Some("mailto:user@example.com".to_string())
+        );
+        assert_eq!(sanitize_email("not-an-email"), None);
+        assert_eq!(sanitize_email("javascript:alert(1)"), None);
+    }
+}

--- a/bbcode-egui/src/lib.rs
+++ b/bbcode-egui/src/lib.rs
@@ -1,0 +1,24 @@
+//! Render bbcode into egui widgets.
+//!
+//! ```ignore
+//! let view = bbcode_egui::BBView::parse(text);
+//! let mut state = bbcode_egui::BBState::default();
+//! view.show(ui, &mut state, "my-bb-view");
+//! ```
+//!
+//! Tags outside the supported set render as their raw bracketed form, so
+//! unrecognized markup stays visible as text. Link URLs are restricted to
+//! `http`, `https`, and `mailto`; image URLs to `http` and `https`.
+//!
+//! With the `entities` feature, HTML numeric (`&#N;`, `&#xN;`) and a small
+//! set of named entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`,
+//! `&nbsp;`) are decoded in text content, and control / bidi formatting
+//! characters are stripped.
+
+mod decode;
+mod ir;
+mod render;
+mod sanitize;
+mod style;
+
+pub use render::{BBState, BBView};

--- a/bbcode-egui/src/render.rs
+++ b/bbcode-egui/src/render.rs
@@ -1,0 +1,264 @@
+use egui::text::LayoutJob;
+use egui::{CollapsingHeader, Color32, Frame, Image, RichText, Sense, Window};
+
+use crate::ir::{Block, HAlign, HiddenKind, Inline, build_blocks};
+use crate::style::Style;
+
+const QUOTE_BAR: Color32 = Color32::from_rgb(120, 120, 120);
+
+pub struct BBView {
+    blocks: Vec<Block>,
+}
+
+#[derive(Default)]
+pub struct BBState {
+    open_image: Option<String>,
+}
+
+struct Ctx<'b> {
+    state: &'b mut BBState,
+    spoiler_index: u32,
+}
+
+impl BBView {
+    pub fn parse(src: &str) -> Self {
+        let doc = bbcode::parse(src);
+        let blocks = build_blocks(&doc.children, &Style::default());
+        Self { blocks }
+    }
+
+    pub fn show(&self, ui: &mut egui::Ui, state: &mut BBState, id_salt: impl std::hash::Hash) {
+        let id_base = ui.id().with("bbcode-egui").with(id_salt);
+        ui.push_id(id_base, |ui| {
+            ui.visuals_mut().indent_has_left_vline = false;
+            let mut ctx = Ctx {
+                state,
+                spoiler_index: 0,
+            };
+            render_blocks(ui, &self.blocks, &mut ctx);
+        });
+        show_image_window(ui.ctx(), state);
+    }
+}
+
+fn render_blocks(ui: &mut egui::Ui, blocks: &[Block], ctx: &mut Ctx<'_>) {
+    for block in blocks {
+        render_block(ui, block, ctx);
+    }
+}
+
+fn render_block(ui: &mut egui::Ui, block: &Block, ctx: &mut Ctx<'_>) {
+    match block {
+        Block::Para(inlines) => render_paragraph(ui, inlines, ctx),
+        Block::List { ordered, items } => {
+            ui.indent("bb-list", |ui| {
+                for (i, item) in items.iter().enumerate() {
+                    ui.horizontal_wrapped(|ui| {
+                        let bullet = if *ordered {
+                            format!("{}.", i + 1)
+                        } else {
+                            "•".to_string()
+                        };
+                        ui.label(RichText::new(bullet).strong());
+                        ui.vertical(|ui| render_blocks(ui, item, ctx));
+                    });
+                }
+            });
+        }
+        Block::Indent(children) => {
+            ui.indent("bb-indent", |ui| render_blocks(ui, children, ctx));
+        }
+        Block::Code(text) => {
+            Frame::group(ui.style())
+                .inner_margin(6.0)
+                .show(ui, |ui| {
+                    ui.label(RichText::new(text).monospace());
+                });
+        }
+        Block::Hidden(kind, children) => {
+            let idx = ctx.spoiler_index;
+            ctx.spoiler_index += 1;
+            let label = match kind {
+                HiddenKind::Spoiler => "Spoiler",
+                HiddenKind::Blur => "Hidden",
+            };
+            CollapsingHeader::new(label)
+                .id_salt(("bb-spoiler", idx))
+                .default_open(false)
+                .show(ui, |ui| render_blocks(ui, children, ctx));
+        }
+        Block::Quote(children) => {
+            Frame::default()
+                .inner_margin(egui::Margin {
+                    left: 8,
+                    right: 4,
+                    top: 2,
+                    bottom: 2,
+                })
+                .stroke(egui::Stroke::new(2.0, QUOTE_BAR))
+                .show(ui, |ui| {
+                    ui.indent("bb-quote", |ui| render_blocks(ui, children, ctx));
+                });
+        }
+        Block::Align(halign, children) => {
+            match halign {
+                HAlign::Left => {
+                    ui.with_layout(
+                        egui::Layout::top_down(egui::Align::Min),
+                        |ui| render_blocks(ui, children, ctx),
+                    );
+                }
+                HAlign::Center => {
+                    ui.vertical_centered(|ui| render_blocks(ui, children, ctx));
+                }
+                HAlign::Right => {
+                    ui.with_layout(
+                        egui::Layout::top_down(egui::Align::Max),
+                        |ui| render_blocks(ui, children, ctx),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn render_paragraph(ui: &mut egui::Ui, inlines: &[Inline], ctx: &mut Ctx<'_>) {
+    let pane_width = ui.available_width();
+    ui.horizontal_wrapped(|ui| {
+        ui.spacing_mut().item_spacing.x = 0.0;
+        let mut current = LayoutJob::default();
+        let mut current_has_content = false;
+        for inline in inlines {
+            match inline {
+                Inline::Text { text, style } => {
+                    if text.is_empty() {
+                        continue;
+                    }
+                    let tf = style.to_text_format(ui);
+                    current.append(text, 0.0, tf);
+                    current_has_content = true;
+                }
+                Inline::Link { label, url } => {
+                    flush_job(ui, &mut current, &mut current_has_content);
+                    let mut job = LayoutJob::default();
+                    let link_color = ui.visuals().hyperlink_color;
+                    for inl in label {
+                        if let Inline::Text { text, style } = inl {
+                            let mut s = style.clone();
+                            s.color = Some(link_color);
+                            s.underline = true;
+                            let tf = s.to_text_format(ui);
+                            job.append(text, 0.0, tf);
+                        }
+                    }
+                    if job.is_empty() {
+                        job.append(
+                            url,
+                            0.0,
+                            egui::TextFormat {
+                                color: link_color,
+                                underline: egui::Stroke::new(1.0, link_color),
+                                font_id: egui::FontId::proportional(14.0),
+                                ..Default::default()
+                            },
+                        );
+                    }
+                    let resp = ui.add(egui::Label::new(job).sense(Sense::click()));
+                    if resp.hovered() {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                    }
+                    if resp.clicked() {
+                        ui.ctx().open_url(egui::OpenUrl::new_tab(url));
+                    }
+                }
+                Inline::Image(url) => {
+                    flush_job(ui, &mut current, &mut current_has_content);
+                    // TODO(egui_extras image MIME bug): some servers send a
+                    // parameterised Content-Type (e.g. `image/png; charset=UTF-8`).
+                    // egui_extras 0.33 ImageCrateLoader::is_supported_mime does an
+                    // exact string match against image::ImageFormat::from_mime_type,
+                    // which only knows canonical names — so the bytes load fine but
+                    // the loader returns FormatNotSupported and a red triangle is
+                    // shown. Fixed upstream in egui_extras 0.34 by stripping the
+                    // `;` parameter; revisit when we upgrade.
+                    let resp = ui.add(
+                        Image::new(url.as_str())
+                            .fit_to_original_size(1.0)
+                            .max_width(pane_width)
+                            .maintain_aspect_ratio(true)
+                            .sense(Sense::click()),
+                    )
+                    .on_hover_text(short_host(url));
+                    if resp.hovered() {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                    }
+                    if resp.clicked() {
+                        ctx.state.open_image = Some(url.clone());
+                    }
+                }
+                Inline::Youtube(id) => {
+                    flush_job(ui, &mut current, &mut current_has_content);
+                    let url = format!("https://www.youtube.com/watch?v={id}");
+                    let label = format!("▶ youtube:{id}");
+                    if ui.link(label).clicked() {
+                        ui.ctx().open_url(egui::OpenUrl::new_tab(url));
+                    }
+                }
+            }
+        }
+        flush_job(ui, &mut current, &mut current_has_content);
+    });
+}
+
+fn flush_job(ui: &mut egui::Ui, job: &mut LayoutJob, has_content: &mut bool) {
+    if !*has_content {
+        return;
+    }
+    let taken = std::mem::take(job);
+    ui.label(taken);
+    *has_content = false;
+}
+
+fn short_host(url: &str) -> String {
+    let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
+    let host = after_scheme.split(['/', '?', '#']).next().unwrap_or(url);
+    host.to_string()
+}
+
+fn show_image_window(ctx: &egui::Context, state: &mut BBState) {
+    let Some(url) = state.open_image.clone() else {
+        return;
+    };
+    let mut open = true;
+    Window::new("Image")
+        .open(&mut open)
+        .resizable(true)
+        .default_size([640.0, 480.0])
+        .show(ctx, |ui| {
+            ui.vertical(|ui| {
+                ui.horizontal(|ui| {
+                    ui.label(RichText::new(&url).small().monospace());
+                    if ui.small_button("Open in browser").clicked() {
+                        ctx.open_url(egui::OpenUrl::new_tab(url.clone()));
+                    }
+                });
+                ui.separator();
+                egui::ScrollArea::both().show(ui, |ui| {
+                    ui.add(Image::new(url.as_str()).shrink_to_fit());
+                });
+            });
+        });
+    if !open {
+        state.open_image = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn short_host_strips_path() {
+        assert_eq!(short_host("https://i.imgur.com/foo.png"), "i.imgur.com");
+        assert_eq!(short_host("http://example.com/a?b=1"), "example.com");
+    }
+}

--- a/bbcode-egui/src/sanitize.rs
+++ b/bbcode-egui/src/sanitize.rs
@@ -1,0 +1,280 @@
+use egui::Color32;
+
+pub fn parse_color(raw: &str) -> Option<Color32> {
+    let s = bbcode::unquote(raw).trim();
+    if s.is_empty() {
+        return None;
+    }
+    if let Some(c) = parse_hex(s) {
+        return Some(c);
+    }
+    let lower = s.to_ascii_lowercase();
+    NAMED_COLORS
+        .iter()
+        .find(|(name, _)| *name == lower.as_str())
+        .map(|(_, rgb)| Color32::from_rgb(rgb[0], rgb[1], rgb[2]))
+}
+
+fn parse_hex(s: &str) -> Option<Color32> {
+    let body = s.strip_prefix('#').unwrap_or(s);
+    let valid = body.len() == 3 || body.len() == 6;
+    if !valid || !body.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let n = match body.len() {
+        3 => 6,
+        6 => 6,
+        _ => return None,
+    };
+    let _ = n;
+    let expand = |c: char| -> u8 { c.to_digit(16).unwrap() as u8 };
+    if body.len() == 3 {
+        let cs: Vec<char> = body.chars().collect();
+        Some(Color32::from_rgb(
+            expand(cs[0]) * 17,
+            expand(cs[1]) * 17,
+            expand(cs[2]) * 17,
+        ))
+    } else {
+        let r = u8::from_str_radix(&body[0..2], 16).ok()?;
+        let g = u8::from_str_radix(&body[2..4], 16).ok()?;
+        let b = u8::from_str_radix(&body[4..6], 16).ok()?;
+        Some(Color32::from_rgb(r, g, b))
+    }
+}
+
+pub fn sanitize_url(raw: &str) -> Option<String> {
+    sanitize_with_schemes(raw, &["http://", "https://", "mailto:"])
+}
+
+pub fn sanitize_image_url(raw: &str) -> Option<String> {
+    sanitize_with_schemes(raw, &["http://", "https://"])
+}
+
+fn sanitize_with_schemes(raw: &str, schemes: &[&str]) -> Option<String> {
+    let s = bbcode::unquote(raw).trim();
+    if s.is_empty() {
+        return None;
+    }
+    let lower = s.to_ascii_lowercase();
+    if schemes.iter().any(|p| lower.starts_with(p)) {
+        Some(s.to_string())
+    } else {
+        None
+    }
+}
+
+pub fn sanitize_youtube_id(raw: &str) -> Option<String> {
+    let s = raw.trim();
+    if s.is_empty() || s.len() > 32 {
+        return None;
+    }
+    if s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-') {
+        Some(s.to_string())
+    } else {
+        None
+    }
+}
+
+#[rustfmt::skip]
+const NAMED_COLORS: &[(&str, [u8; 3])] = &[
+    ("aliceblue", [240, 248, 255]),
+    ("antiquewhite", [250, 235, 215]),
+    ("aqua", [0, 255, 255]),
+    ("aquamarine", [127, 255, 212]),
+    ("azure", [240, 255, 255]),
+    ("beige", [245, 245, 220]),
+    ("bisque", [255, 228, 196]),
+    ("black", [0, 0, 0]),
+    ("blanchedalmond", [255, 235, 205]),
+    ("blue", [0, 0, 255]),
+    ("blueviolet", [138, 43, 226]),
+    ("brown", [165, 42, 42]),
+    ("burlywood", [222, 184, 135]),
+    ("cadetblue", [95, 158, 160]),
+    ("chartreuse", [127, 255, 0]),
+    ("chocolate", [210, 105, 30]),
+    ("coral", [255, 127, 80]),
+    ("cornflowerblue", [100, 149, 237]),
+    ("cornsilk", [255, 248, 220]),
+    ("crimson", [220, 20, 60]),
+    ("cyan", [0, 255, 255]),
+    ("darkblue", [0, 0, 139]),
+    ("darkcyan", [0, 139, 139]),
+    ("darkgoldenrod", [184, 134, 11]),
+    ("darkgray", [169, 169, 169]),
+    ("darkgreen", [0, 100, 0]),
+    ("darkgrey", [169, 169, 169]),
+    ("darkkhaki", [189, 183, 107]),
+    ("darkmagenta", [139, 0, 139]),
+    ("darkolivegreen", [85, 107, 47]),
+    ("darkorange", [255, 140, 0]),
+    ("darkorchid", [153, 50, 204]),
+    ("darkred", [139, 0, 0]),
+    ("darksalmon", [233, 150, 122]),
+    ("darkseagreen", [143, 188, 143]),
+    ("darkslateblue", [72, 61, 139]),
+    ("darkslategray", [47, 79, 79]),
+    ("darkslategrey", [47, 79, 79]),
+    ("darkturquoise", [0, 206, 209]),
+    ("darkviolet", [148, 0, 211]),
+    ("deeppink", [255, 20, 147]),
+    ("deepskyblue", [0, 191, 255]),
+    ("dimgray", [105, 105, 105]),
+    ("dimgrey", [105, 105, 105]),
+    ("dodgerblue", [30, 144, 255]),
+    ("firebrick", [178, 34, 34]),
+    ("floralwhite", [255, 250, 240]),
+    ("forestgreen", [34, 139, 34]),
+    ("fuchsia", [255, 0, 255]),
+    ("gainsboro", [220, 220, 220]),
+    ("ghostwhite", [248, 248, 255]),
+    ("gold", [255, 215, 0]),
+    ("goldenrod", [218, 165, 32]),
+    ("gray", [128, 128, 128]),
+    ("green", [0, 128, 0]),
+    ("greenyellow", [173, 255, 47]),
+    ("grey", [128, 128, 128]),
+    ("honeydew", [240, 255, 240]),
+    ("hotpink", [255, 105, 180]),
+    ("indianred", [205, 92, 92]),
+    ("indigo", [75, 0, 130]),
+    ("ivory", [255, 255, 240]),
+    ("khaki", [240, 230, 140]),
+    ("lavender", [230, 230, 250]),
+    ("lavenderblush", [255, 240, 245]),
+    ("lawngreen", [124, 252, 0]),
+    ("lemonchiffon", [255, 250, 205]),
+    ("lightblue", [173, 216, 230]),
+    ("lightcoral", [240, 128, 128]),
+    ("lightcyan", [224, 255, 255]),
+    ("lightgoldenrodyellow", [250, 250, 210]),
+    ("lightgray", [211, 211, 211]),
+    ("lightgreen", [144, 238, 144]),
+    ("lightgrey", [211, 211, 211]),
+    ("lightpink", [255, 182, 193]),
+    ("lightsalmon", [255, 160, 122]),
+    ("lightseagreen", [32, 178, 170]),
+    ("lightskyblue", [135, 206, 250]),
+    ("lightslategray", [119, 136, 153]),
+    ("lightslategrey", [119, 136, 153]),
+    ("lightsteelblue", [176, 196, 222]),
+    ("lightyellow", [255, 255, 224]),
+    ("lime", [0, 255, 0]),
+    ("limegreen", [50, 205, 50]),
+    ("linen", [250, 240, 230]),
+    ("magenta", [255, 0, 255]),
+    ("maroon", [128, 0, 0]),
+    ("mediumaquamarine", [102, 205, 170]),
+    ("mediumblue", [0, 0, 205]),
+    ("mediumorchid", [186, 85, 211]),
+    ("mediumpurple", [147, 112, 219]),
+    ("mediumseagreen", [60, 179, 113]),
+    ("mediumslateblue", [123, 104, 238]),
+    ("mediumspringgreen", [0, 250, 154]),
+    ("mediumturquoise", [72, 209, 204]),
+    ("mediumvioletred", [199, 21, 133]),
+    ("midnightblue", [25, 25, 112]),
+    ("mintcream", [245, 255, 250]),
+    ("mistyrose", [255, 228, 225]),
+    ("moccasin", [255, 228, 181]),
+    ("navajowhite", [255, 222, 173]),
+    ("navy", [0, 0, 128]),
+    ("oldlace", [253, 245, 230]),
+    ("olive", [128, 128, 0]),
+    ("olivedrab", [107, 142, 35]),
+    ("orange", [255, 165, 0]),
+    ("orangered", [255, 69, 0]),
+    ("orchid", [218, 112, 214]),
+    ("palegoldenrod", [238, 232, 170]),
+    ("palegreen", [152, 251, 152]),
+    ("paleturquoise", [175, 238, 238]),
+    ("palevioletred", [219, 112, 147]),
+    ("papayawhip", [255, 239, 213]),
+    ("peachpuff", [255, 218, 185]),
+    ("peru", [205, 133, 63]),
+    ("pink", [255, 192, 203]),
+    ("plum", [221, 160, 221]),
+    ("powderblue", [176, 224, 230]),
+    ("purple", [128, 0, 128]),
+    ("rebeccapurple", [102, 51, 153]),
+    ("red", [255, 0, 0]),
+    ("rosybrown", [188, 143, 143]),
+    ("royalblue", [65, 105, 225]),
+    ("saddlebrown", [139, 69, 19]),
+    ("salmon", [250, 128, 114]),
+    ("sandybrown", [244, 164, 96]),
+    ("seagreen", [46, 139, 87]),
+    ("seashell", [255, 245, 238]),
+    ("sienna", [160, 82, 45]),
+    ("silver", [192, 192, 192]),
+    ("skyblue", [135, 206, 235]),
+    ("slateblue", [106, 90, 205]),
+    ("slategray", [112, 128, 144]),
+    ("slategrey", [112, 128, 144]),
+    ("snow", [255, 250, 250]),
+    ("springgreen", [0, 255, 127]),
+    ("steelblue", [70, 130, 180]),
+    ("tan", [210, 180, 140]),
+    ("teal", [0, 128, 128]),
+    ("thistle", [216, 191, 216]),
+    ("tomato", [255, 99, 71]),
+    ("turquoise", [64, 224, 208]),
+    ("violet", [238, 130, 238]),
+    ("wheat", [245, 222, 179]),
+    ("white", [255, 255, 255]),
+    ("whitesmoke", [245, 245, 245]),
+    ("yellow", [255, 255, 0]),
+    ("yellowgreen", [154, 205, 50]),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn named_color() {
+        assert_eq!(parse_color("\"DarkOrange\""), Some(Color32::from_rgb(255, 140, 0)));
+        assert_eq!(parse_color("red"), Some(Color32::from_rgb(255, 0, 0)));
+    }
+
+    #[test]
+    fn hex_color() {
+        assert_eq!(parse_color("#FF8800"), Some(Color32::from_rgb(0xff, 0x88, 0x00)));
+        assert_eq!(parse_color("ff8800"), Some(Color32::from_rgb(0xff, 0x88, 0x00)));
+        assert_eq!(parse_color("#abc"), Some(Color32::from_rgb(0xaa, 0xbb, 0xcc)));
+    }
+
+    #[test]
+    fn invalid_color() {
+        assert_eq!(parse_color("not-a-color"), None);
+        assert_eq!(parse_color(""), None);
+        assert_eq!(parse_color("#xyz"), None);
+    }
+
+    #[test]
+    fn url_allowlist() {
+        assert!(sanitize_url("https://example.com").is_some());
+        assert!(sanitize_url("\"http://x\"").is_some());
+        assert!(sanitize_url("mailto:a@b").is_some());
+        assert!(sanitize_url("javascript:alert(1)").is_none());
+        assert!(sanitize_url("file:///etc/passwd").is_none());
+        assert!(sanitize_url("ftp://example.com").is_none());
+    }
+
+    #[test]
+    fn image_url_allowlist() {
+        assert!(sanitize_image_url("https://example.com/x.png").is_some());
+        assert!(sanitize_image_url("http://example.com/x.png").is_some());
+        assert!(sanitize_image_url("mailto:a@b").is_none());
+        assert!(sanitize_image_url("javascript:alert(1)").is_none());
+        assert!(sanitize_image_url("file:///etc/passwd").is_none());
+    }
+
+    #[test]
+    fn youtube_id() {
+        assert_eq!(sanitize_youtube_id("abc-DEF_123"), Some("abc-DEF_123".to_string()));
+        assert!(sanitize_youtube_id("a b").is_none());
+        assert!(sanitize_youtube_id("a; rm -rf /").is_none());
+    }
+}

--- a/bbcode-egui/src/style.rs
+++ b/bbcode-egui/src/style.rs
@@ -1,0 +1,84 @@
+use egui::{Color32, FontId, Stroke, TextFormat};
+
+#[derive(Clone, Debug)]
+pub struct Style {
+    pub bold: bool,
+    pub italic: bool,
+    pub underline: bool,
+    pub strike: bool,
+    pub color: Option<Color32>,
+    pub size_pt: f32,
+    pub monospace: bool,
+}
+
+impl Default for Style {
+    fn default() -> Self {
+        Self {
+            bold: false,
+            italic: false,
+            underline: false,
+            strike: false,
+            color: None,
+            size_pt: 14.0,
+            monospace: false,
+        }
+    }
+}
+
+impl Style {
+    pub fn to_text_format(&self, ui: &egui::Ui) -> TextFormat {
+        let visuals = ui.visuals();
+        let base = visuals.text_color();
+        let color = if self.bold {
+            self.color.unwrap_or(visuals.strong_text_color())
+        } else {
+            self.color.unwrap_or(base)
+        };
+        let stroke_color = self.color.unwrap_or(base);
+        let underline = if self.underline {
+            Stroke::new(1.0, stroke_color)
+        } else {
+            Stroke::NONE
+        };
+        let strike = if self.strike {
+            Stroke::new(1.0, stroke_color)
+        } else {
+            Stroke::NONE
+        };
+        let font_id = if self.monospace {
+            FontId::monospace(self.size_pt)
+        } else {
+            FontId::proportional(self.size_pt)
+        };
+        let mut tf = TextFormat {
+            font_id,
+            color,
+            underline,
+            strikethrough: strike,
+            italics: self.italic,
+            ..Default::default()
+        };
+        if self.bold {
+            tf.color = color;
+        }
+        tf
+    }
+}
+
+pub fn size_from_attr(attr: Option<&str>, _base_pt: f32) -> Option<f32> {
+    let raw = bbcode::unquote(attr?).trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let (sign, num_str) = match raw.as_bytes()[0] {
+        b'+' => (1i32, &raw[1..]),
+        b'-' => (-1i32, &raw[1..]),
+        _ => (0, raw),
+    };
+    let n: i32 = num_str.parse().ok()?;
+    let level = if sign == 0 { n } else { 4 + sign * n };
+    let level = level.clamp(1, 7);
+    Some(SIZE_TABLE[(level - 1) as usize])
+}
+
+const SIZE_TABLE: [f32; 7] = [10.0, 12.0, 14.0, 16.0, 18.0, 22.0, 28.0];

--- a/bbcode/Cargo.toml
+++ b/bbcode/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "bbcode"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "BBCode tokenizer and tree parser"

--- a/bbcode/src/lexer.rs
+++ b/bbcode/src/lexer.rs
@@ -1,0 +1,222 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Token<'a> {
+    Text(&'a str),
+    Open {
+        tag: &'a str,
+        attr: Option<&'a str>,
+        raw: &'a str,
+    },
+    Close {
+        tag: &'a str,
+        raw: &'a str,
+    },
+    Star {
+        raw: &'a str,
+    },
+}
+
+pub fn tokenize(input: &str) -> Vec<Token<'_>> {
+    let bytes = input.as_bytes();
+    let mut out = Vec::new();
+    let mut text_start = 0usize;
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        if bytes[i] != b'[' {
+            i += 1;
+            continue;
+        }
+
+        if let Some((tok, end)) = scan_tag(input, i) {
+            if text_start < i {
+                out.push(Token::Text(&input[text_start..i]));
+            }
+            out.push(tok);
+            i = end;
+            text_start = end;
+            continue;
+        }
+
+        i += 1;
+    }
+
+    if text_start < bytes.len() {
+        out.push(Token::Text(&input[text_start..]));
+    }
+    out
+}
+
+fn scan_tag(input: &str, start: usize) -> Option<(Token<'_>, usize)> {
+    let bytes = input.as_bytes();
+    debug_assert_eq!(bytes[start], b'[');
+
+    let mut p = start + 1;
+    let mut closing = false;
+    if p < bytes.len() && bytes[p] == b'/' {
+        closing = true;
+        p += 1;
+    }
+
+    if p < bytes.len() && bytes[p] == b'*' && !closing {
+        if p + 1 < bytes.len() && bytes[p + 1] == b']' {
+            let end = p + 2;
+            return Some((
+                Token::Star {
+                    raw: &input[start..end],
+                },
+                end,
+            ));
+        }
+        return None;
+    }
+
+    let name_start = p;
+    if p >= bytes.len() || !bytes[p].is_ascii_alphabetic() {
+        return None;
+    }
+    p += 1;
+    while p < bytes.len() {
+        let b = bytes[p];
+        if b.is_ascii_alphanumeric() || b == b'_' || b == b'*' {
+            p += 1;
+        } else {
+            break;
+        }
+    }
+    let name = &input[name_start..p];
+
+    if closing {
+        if p < bytes.len() && bytes[p] == b']' {
+            let end = p + 1;
+            return Some((
+                Token::Close {
+                    tag: name,
+                    raw: &input[start..end],
+                },
+                end,
+            ));
+        }
+        return None;
+    }
+
+    let mut attr: Option<&str> = None;
+    if p < bytes.len() && bytes[p] == b'=' {
+        p += 1;
+        let attr_start = p;
+        let mut quote: Option<u8> = None;
+        if p < bytes.len() && (bytes[p] == b'"' || bytes[p] == b'\'') {
+            quote = Some(bytes[p]);
+            p += 1;
+        }
+        while p < bytes.len() {
+            let b = bytes[p];
+            if let Some(q) = quote {
+                if b == q {
+                    p += 1;
+                    break;
+                }
+                if b == b'\n' || b == b'\r' {
+                    return None;
+                }
+                p += 1;
+            } else {
+                if b == b']' {
+                    break;
+                }
+                if b == b'\n' || b == b'\r' {
+                    return None;
+                }
+                p += 1;
+            }
+        }
+        attr = Some(&input[attr_start..p]);
+    }
+
+    if p >= bytes.len() || bytes[p] != b']' {
+        return None;
+    }
+    let end = p + 1;
+    Some((
+        Token::Open {
+            tag: name,
+            attr,
+            raw: &input[start..end],
+        },
+        end,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_text() {
+        let toks = tokenize("hello world");
+        assert_eq!(toks, vec![Token::Text("hello world")]);
+    }
+
+    #[test]
+    fn simple_pair() {
+        let toks = tokenize("[b]hi[/b]");
+        assert_eq!(
+            toks,
+            vec![
+                Token::Open {
+                    tag: "b",
+                    attr: None,
+                    raw: "[b]"
+                },
+                Token::Text("hi"),
+                Token::Close {
+                    tag: "b",
+                    raw: "[/b]"
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn quoted_attr() {
+        let toks = tokenize(r#"[color="Red"]x[/color]"#);
+        assert_eq!(toks[0], Token::Open {
+            tag: "color",
+            attr: Some(r#""Red""#),
+            raw: r#"[color="Red"]"#,
+        });
+    }
+
+    #[test]
+    fn unquoted_attr() {
+        let toks = tokenize("[size=4]x[/size]");
+        assert_eq!(toks[0], Token::Open {
+            tag: "size",
+            attr: Some("4"),
+            raw: "[size=4]",
+        });
+    }
+
+    #[test]
+    fn star() {
+        let toks = tokenize("[*]item");
+        assert_eq!(toks[0], Token::Star { raw: "[*]" });
+    }
+
+    #[test]
+    fn malformed_left_alone() {
+        let toks = tokenize("price [25] tokens");
+        assert_eq!(toks, vec![Token::Text("price [25] tokens")]);
+    }
+
+    #[test]
+    fn unterminated_open() {
+        let toks = tokenize("foo [b bar");
+        assert_eq!(toks, vec![Token::Text("foo [b bar")]);
+    }
+
+    #[test]
+    fn newline_breaks_attr() {
+        let toks = tokenize("[url=http://x\n]y[/url]");
+        assert!(matches!(toks[0], Token::Text(_)));
+    }
+}

--- a/bbcode/src/lib.rs
+++ b/bbcode/src/lib.rs
@@ -1,0 +1,53 @@
+//! BBCode tokenizer and tree parser.
+//!
+//! `parse(&str)` returns a [`Document`] that borrows from the input.
+
+mod lexer;
+mod parser;
+mod sexp;
+
+pub use lexer::{Token, tokenize};
+pub use parser::parse;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Document<'a> {
+    pub children: Vec<Node<'a>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Node<'a> {
+    Text(&'a str),
+    Element(Element<'a>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Element<'a> {
+    pub tag: &'a str,
+    pub attr: Option<&'a str>,
+    pub raw_open: &'a str,
+    pub children: Vec<Node<'a>>,
+    pub auto_closed: bool,
+}
+
+impl Element<'_> {
+    pub fn is(&self, name: &str) -> bool {
+        self.tag.eq_ignore_ascii_case(name)
+    }
+
+    pub fn attr_value(&self) -> Option<&str> {
+        self.attr.map(unquote)
+    }
+}
+
+pub fn unquote(s: &str) -> &str {
+    let s = s.trim();
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2
+        && ((bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[bytes.len() - 1] == b'\''))
+    {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}

--- a/bbcode/src/parser.rs
+++ b/bbcode/src/parser.rs
@@ -1,0 +1,308 @@
+use crate::lexer::{Token, tokenize};
+use crate::{Document, Element, Node};
+
+const MAX_DEPTH: usize = 64;
+
+fn is_list_tag(tag: &str) -> bool {
+    tag.eq_ignore_ascii_case("list")
+        || tag.eq_ignore_ascii_case("ul")
+        || tag.eq_ignore_ascii_case("ol")
+}
+
+fn is_list_item_tag(tag: &str) -> bool {
+    tag == "*" || tag.eq_ignore_ascii_case("li")
+}
+
+struct Frame<'a> {
+    tag: &'a str,
+    attr: Option<&'a str>,
+    raw_open: &'a str,
+    children: Vec<Node<'a>>,
+}
+
+pub fn parse(input: &str) -> Document<'_> {
+    let tokens = tokenize(input);
+    let mut stack: Vec<Frame<'_>> = vec![Frame {
+        tag: "",
+        attr: None,
+        raw_open: "",
+        children: Vec::new(),
+    }];
+
+    for tok in tokens {
+        match tok {
+            Token::Text(s) => push_text(&mut stack, s),
+
+            Token::Open { tag, attr, raw } => {
+                if stack.len() > MAX_DEPTH {
+                    push_text(&mut stack, raw);
+                    continue;
+                }
+                if is_list_item_tag(tag) {
+                    open_list_item(&mut stack, tag, attr, raw);
+                    continue;
+                }
+                stack.push(Frame {
+                    tag,
+                    attr,
+                    raw_open: raw,
+                    children: Vec::new(),
+                });
+            }
+
+            Token::Close { tag, raw } => {
+                let idx = stack.iter().rposition(|f| f.tag.eq_ignore_ascii_case(tag));
+                match idx {
+                    Some(target) if target >= 1 => {
+                        while stack.len() > target + 1 {
+                            close_top(&mut stack, true);
+                        }
+                        close_top(&mut stack, false);
+                    }
+                    _ => push_text(&mut stack, raw),
+                }
+            }
+
+            Token::Star { raw } => {
+                open_list_item(&mut stack, "*", None, raw);
+            }
+        }
+    }
+
+    while stack.len() > 1 {
+        close_top(&mut stack, true);
+    }
+
+    Document {
+        children: stack.pop().unwrap().children,
+    }
+}
+
+fn open_list_item<'a>(
+    stack: &mut Vec<Frame<'a>>,
+    tag: &'a str,
+    attr: Option<&'a str>,
+    raw: &'a str,
+) {
+    let list_idx = stack.iter().rposition(|f| is_list_tag(f.tag));
+    let item_idx = stack.iter().rposition(|f| is_list_item_tag(f.tag));
+    match (list_idx, item_idx) {
+        (Some(li), Some(ii)) if ii > li => {
+            while stack.len() > ii + 1 {
+                close_top(stack, true);
+            }
+            close_top(stack, true);
+            stack.push(Frame {
+                tag,
+                attr,
+                raw_open: raw,
+                children: Vec::new(),
+            });
+        }
+        (Some(_), _) => {
+            stack.push(Frame {
+                tag,
+                attr,
+                raw_open: raw,
+                children: Vec::new(),
+            });
+        }
+        _ => push_text(stack, raw),
+    }
+}
+
+fn push_text<'a>(stack: &mut Vec<Frame<'a>>, s: &'a str) {
+    if s.is_empty() {
+        return;
+    }
+    stack.last_mut().unwrap().children.push(Node::Text(s));
+}
+
+fn close_top<'a>(stack: &mut Vec<Frame<'a>>, auto_closed: bool) {
+    let frame = stack.pop().unwrap();
+    let element = Element {
+        tag: frame.tag,
+        attr: frame.attr,
+        raw_open: frame.raw_open,
+        children: frame.children,
+        auto_closed,
+    };
+    stack
+        .last_mut()
+        .unwrap()
+        .children
+        .push(Node::Element(element));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_one_text<'a>(node: &Node<'a>, expected: &str) {
+        match node {
+            Node::Text(s) => assert_eq!(*s, expected),
+            other => panic!("expected text, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn simple_pair() {
+        let d = parse("[b]hi[/b]");
+        assert_eq!(d.children.len(), 1);
+        if let Node::Element(e) = &d.children[0] {
+            assert!(e.is("b"));
+            assert!(!e.auto_closed);
+            assert_eq!(e.children.len(), 1);
+            assert_one_text(&e.children[0], "hi");
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn nested() {
+        let d = parse("[b][i]a[/i][/b]");
+        if let Node::Element(b) = &d.children[0] {
+            assert!(b.is("b"));
+            if let Node::Element(i) = &b.children[0] {
+                assert!(i.is("i"));
+                assert_one_text(&i.children[0], "a");
+                return;
+            }
+        }
+        panic!();
+    }
+
+    #[test]
+    fn unmatched_close_is_text() {
+        let d = parse("foo[/b]");
+        assert_eq!(d.children.len(), 2);
+        assert_one_text(&d.children[0], "foo");
+        assert_one_text(&d.children[1], "[/b]");
+    }
+
+    #[test]
+    fn unclosed_open_auto_closes() {
+        let d = parse("[b]hi");
+        if let Node::Element(e) = &d.children[0] {
+            assert!(e.is("b"));
+            assert!(e.auto_closed);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn list_items() {
+        let d = parse("[list][*]a[*]b[/list]");
+        let list = if let Node::Element(e) = &d.children[0] { e } else { panic!() };
+        assert!(list.is("list"));
+        assert_eq!(list.children.len(), 2);
+        for (i, expected) in ["a", "b"].iter().enumerate() {
+            if let Node::Element(item) = &list.children[i] {
+                assert_eq!(item.tag, "*");
+                assert!(item.auto_closed);
+                assert_one_text(&item.children[0], expected);
+            } else {
+                panic!();
+            }
+        }
+    }
+
+    #[test]
+    fn star_outside_list_is_text() {
+        let d = parse("[*]hi");
+        assert_eq!(d.children.len(), 2);
+        assert_one_text(&d.children[0], "[*]");
+        assert_one_text(&d.children[1], "hi");
+    }
+
+    #[test]
+    fn case_insensitive_close() {
+        let d = parse("[B]hi[/b]");
+        if let Node::Element(e) = &d.children[0] {
+            assert!(e.is("b"));
+            assert!(!e.auto_closed);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn cross_close_auto_closes_inner() {
+        let d = parse("[b][i]hi[/b]");
+        if let Node::Element(b) = &d.children[0] {
+            assert!(b.is("b"));
+            assert!(!b.auto_closed);
+            if let Node::Element(i) = &b.children[0] {
+                assert!(i.is("i"));
+                assert!(i.auto_closed);
+                return;
+            }
+        }
+        panic!();
+    }
+
+    #[test]
+    fn attrs() {
+        let d = parse(r#"[url="http://x"]y[/url]"#);
+        if let Node::Element(e) = &d.children[0] {
+            assert!(e.is("url"));
+            assert_eq!(e.attr, Some(r#""http://x""#));
+            assert_eq!(e.attr_value(), Some("http://x"));
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn ul_li_aliases() {
+        let d = parse("[ul][li]a[/li][li]b[/li][/ul]");
+        let list = if let Node::Element(e) = &d.children[0] { e } else { panic!() };
+        assert!(list.is("ul"));
+        assert_eq!(list.children.len(), 2);
+        for (i, expected) in ["a", "b"].iter().enumerate() {
+            if let Node::Element(item) = &list.children[i] {
+                assert!(item.is("li"));
+                assert!(!item.auto_closed);
+                assert_one_text(&item.children[0], expected);
+            } else {
+                panic!();
+            }
+        }
+    }
+
+    #[test]
+    fn ol_li_implicit_close() {
+        let d = parse("[ol][li]a[li]b[/ol]");
+        let list = if let Node::Element(e) = &d.children[0] { e } else { panic!() };
+        assert!(list.is("ol"));
+        assert_eq!(list.children.len(), 2);
+        for (i, expected) in ["a", "b"].iter().enumerate() {
+            if let Node::Element(item) = &list.children[i] {
+                assert!(item.is("li"));
+                assert!(item.auto_closed);
+                assert_one_text(&item.children[0], expected);
+            } else {
+                panic!();
+            }
+        }
+    }
+
+    #[test]
+    fn star_inside_ul() {
+        let d = parse("[ul][*]a[*]b[/ul]");
+        let list = if let Node::Element(e) = &d.children[0] { e } else { panic!() };
+        assert!(list.is("ul"));
+        assert_eq!(list.children.len(), 2);
+    }
+
+    #[test]
+    fn unmatched_close_split_into_text() {
+        let d = parse("foo[/b]bar");
+        assert_eq!(d.children.len(), 3);
+        assert_one_text(&d.children[0], "foo");
+        assert_one_text(&d.children[1], "[/b]");
+        assert_one_text(&d.children[2], "bar");
+    }
+}

--- a/bbcode/src/sexp.rs
+++ b/bbcode/src/sexp.rs
@@ -1,0 +1,84 @@
+use std::fmt::{self, Write};
+
+use crate::{Document, Element, Node};
+
+impl fmt::Display for Document<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("(doc")?;
+        for child in &self.children {
+            f.write_str(" ")?;
+            child.fmt(f)?;
+        }
+        f.write_str(")")
+    }
+}
+
+impl fmt::Display for Node<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Node::Text(s) => write_quoted(f, s),
+            Node::Element(e) => e.fmt(f),
+        }
+    }
+}
+
+impl fmt::Display for Element<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("(")?;
+        f.write_str(self.tag)?;
+        if let Some(attr) = self.attr {
+            f.write_str(" :attr ")?;
+            write_quoted(f, crate::unquote(attr))?;
+        }
+        if self.auto_closed {
+            f.write_str(" :auto-closed")?;
+        }
+        for child in &self.children {
+            f.write_str(" ")?;
+            child.fmt(f)?;
+        }
+        f.write_str(")")
+    }
+}
+
+fn write_quoted(f: &mut fmt::Formatter<'_>, s: &str) -> fmt::Result {
+    f.write_str("\"")?;
+    for c in s.chars() {
+        match c {
+            '"' => f.write_str("\\\"")?,
+            '\\' => f.write_str("\\\\")?,
+            '\n' => f.write_str("\\n")?,
+            '\r' => f.write_str("\\r")?,
+            '\t' => f.write_str("\\t")?,
+            c if (c as u32) < 0x20 => write!(f, "\\x{:02x}", c as u32)?,
+            c => f.write_char(c)?,
+        }
+    }
+    f.write_str("\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parse;
+
+    #[test]
+    fn round_trip_sexp() {
+        let s = parse(r#"[b]hello[i]world[/i][/b]"#).to_string();
+        assert_eq!(s, r#"(doc (b "hello" (i "world")))"#);
+    }
+
+    #[test]
+    fn list_sexp() {
+        let s = parse("[list][*]a[*]b[/list]").to_string();
+        assert_eq!(
+            s,
+            r#"(doc (list (* :auto-closed "a") (* :auto-closed "b")))"#
+        );
+    }
+
+    #[test]
+    fn attr_sexp() {
+        let s = parse(r#"[color="Red"]hi[/color]"#).to_string();
+        assert_eq!(s, r#"(doc (color :attr "Red" "hi"))"#);
+    }
+}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,7 +35,6 @@ entity = { path = "../entity" }
 tracing = "0.1.44"
 chrono = "0.4.44"
 lazy_async_promise = "0.6.0"
-bbcode-tagger = "0.2.0"
 md-5 = "0.10.6"
 version-compare = "0.2.1"
 eso_addon_manifest = "0.1.5"

--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -22,7 +22,6 @@ use entity::installed_addon as InstalledAddon;
 use entity::manual_dependency as ManualDependency;
 use migration::{Condition, Migrator, MigratorTrait};
 
-use bbcode_tagger::{BBCode, BBTree};
 use lazy_async_promise::ImmediateValuePromise;
 use md5::{Digest, Md5};
 use sea_orm::sea_query::{Expr, OnConflict};
@@ -767,14 +766,6 @@ where i.addon_id is null
             if result.is_none() {
                 warn!("No details found for addon: {addon_id}");
             }
-            Ok(result)
-        })
-    }
-
-    pub fn parse_bbcode(&self, text: String) -> ImmediateValuePromise<BBTree> {
-        ImmediateValuePromise::new(async move {
-            let parser = BBCode::default();
-            let result = parser.parse(&text);
             Ok(result)
         })
     }

--- a/src/views/addon_details.rs
+++ b/src/views/addon_details.rs
@@ -1,22 +1,14 @@
 use super::{
     ResetView, View,
-    ui_helpers::{
-        AddonResponse,
-        AddonResponseType,
-        PromisedValue,
-        // ui_show_bbtree,
-        truncate_len,
-        ui_show_star,
-    },
+    ui_helpers::{AddonResponse, AddonResponseType, PromisedValue, truncate_len, ui_show_star},
 };
-// use bbcode_tagger::BBTree;
+use bbcode_egui::{BBState, BBView};
 use eframe::egui::{self, Image, Layout, RichText, ScrollArea, vec2};
 use egui::Button;
 use eso_addons_core::service::{
     AddonService,
     result::{AddonImageResult, AddonShowDetails},
 };
-// use tracing::info;
 
 #[derive(PartialEq, Default)]
 enum DetailView {
@@ -31,51 +23,49 @@ enum DetailView {
 pub struct Details {
     addon_id: i32,
     details: PromisedValue<Option<AddonShowDetails>>,
-    // parsed_description: PromisedValue<BBTree>,
-    // parsed_changelog: PromisedValue<BBTree>,
     view: DetailView,
-    // show_raw_text: bool,
+    show_raw_text: bool,
+    bb_description: Option<BBView>,
+    bb_description_state: BBState,
+    bb_changelog: Option<BBView>,
+    bb_changelog_state: BBState,
     images: PromisedValue<Vec<AddonImageResult>>,
     selected_image: String,
 }
 
 impl Details {
     fn poll(&mut self, _: &mut AddonService) {
-        // main details
         self.details.poll();
         if self.details.is_ready() {
             self.details.handle();
-
-            // if let Some(details) = self.details.value.as_ref().unwrap() {
-            // we have details, no setup parse for details and changelog if present
-            // if let Some(description) = details.description.as_ref() {
-            // info!("Parsing BBCode for addon description: {}", details.id);
-            // self.parsed_description
-            //     .set(service.parse_bbcode(description.to_string()));
-            // }
-            // if let Some(changelog) = details.change_log.as_ref() {
-            // info!("Parsing BBCode for addon changelog: {}", details.id);
-            // self.parsed_changelog
-            //     .set(service.parse_bbcode(changelog.to_string()));
-            // }
-            // }
+            self.build_bb_views();
         }
-
-        // images
         self.images.poll();
-
-        // self.parsed_description.poll();
-        // self.parsed_changelog.poll();
     }
+
+    fn build_bb_views(&mut self) {
+        if self.bb_description.is_some() && self.bb_changelog.is_some() {
+            return;
+        }
+        let Some(Some(addon)) = self.details.value.as_ref() else {
+            return;
+        };
+        let desc = addon.description.as_deref().unwrap_or("");
+        let cl = addon.change_log.as_deref().unwrap_or("");
+        self.bb_description = Some(BBView::parse(desc));
+        self.bb_changelog = Some(BBView::parse(cl));
+    }
+
     pub fn set_addon(&mut self, addon_id: i32, service: &mut AddonService) {
         self.addon_id = addon_id;
-        // get addon details from service
         self.details.set(service.get_addon_details(addon_id));
-        // get addon image URLs
         self.images.set(service.get_addon_images(addon_id));
-        // if we get a new addon, reset view to description
         self.view = DetailView::default();
         self.selected_image = String::default();
+        self.bb_description = None;
+        self.bb_changelog = None;
+        self.bb_description_state = BBState::default();
+        self.bb_changelog_state = BBState::default();
     }
 }
 impl View for Details {
@@ -93,19 +83,10 @@ impl View for Details {
             return response;
         }
 
-        if self.details.value.as_ref().unwrap().is_none() {
+        let Some(Some(addon)) = self.details.value.as_ref() else {
             ui.label("No addon!");
             return response;
-        }
-
-        let addon = self
-            .details
-            .value
-            .as_ref()
-            .unwrap()
-            .as_ref()
-            .unwrap()
-            .to_owned();
+        };
         egui::TopBottomPanel::top("detail_top").show(ctx, |ui| {
             ui.add_space(5.0);
             ui.horizontal(|ui| {
@@ -115,19 +96,13 @@ impl View for Details {
                 }
 
                 ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
-                    if addon.to_owned().is_upgradable() {
-                        // if self.is_updating_addon(addon.id) {
-                        //     ui.add_enabled(false, egui::Button::new("Updating..."));
-                        // } else if ui.button(RichText::new("⮉ Update").heading()).clicked() {
-                        if ui.button(RichText::new("⮉ Update").heading()).clicked() {
-                            response.addon_id = addon.id;
-                            response.response_type = AddonResponseType::Update;
-                        }
+                    if addon.is_upgradable()
+                        && ui.button(RichText::new("⮉ Update").heading()).clicked()
+                    {
+                        response.addon_id = addon.id;
+                        response.response_type = AddonResponseType::Update;
                     }
                     if !addon.installed {
-                        // if self.is_installing_addon(addon.id) {
-                        //     ui.add_enabled(false, egui::Button::new("Installing..."));
-                        // } else if ui.button(RichText::new("⮋ Install").heading()).clicked() {
                         if ui.button(RichText::new("⮋ Install").heading()).clicked() {
                             response.addon_id = addon.id;
                             response.response_type = AddonResponseType::Install
@@ -141,7 +116,6 @@ impl View for Details {
             ui.add_space(5.0);
 
             ui.horizontal(|ui| {
-                // ui.horizontal(|ui| {
                 ui.label(RichText::new(addon.name.as_str()).heading().strong());
                 if addon
                     .download_total
@@ -153,7 +127,6 @@ impl View for Details {
                 {
                     ui_show_star(ui);
                 }
-                // });
             });
             ui.add_space(5.0);
 
@@ -165,29 +138,27 @@ impl View for Details {
                     )
                     .clicked()
                 {
-                    response.author_name = addon.to_owned().author_name;
+                    response.author_name = addon.author_name.clone();
                     response.response_type = AddonResponseType::AuthorName;
                 }
                 ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
-                    ui.hyperlink_to("Visit Website", addon.to_owned().file_info_url);
+                    ui.hyperlink_to("Visit Website", &addon.file_info_url);
                 });
             });
 
             ui.horizontal(|ui| {
                 // TODO: Add icon
-                ui.label(addon.to_owned().category);
+                ui.label(addon.category.as_str());
                 ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
                     // TODO: pretty format date like: January 1, 2024
                     ui.label(format!("🕘 Updated {}", addon.date));
                 });
             });
             ui.horizontal(|ui| {
-                if let Some(compat_version) = addon.to_owned().game_compat_version {
-                    ui.label(format!(
-                        "⛭ {} ({}) Supported",
-                        addon.to_owned().game_compat_name.unwrap(),
-                        compat_version
-                    ));
+                if let (Some(name), Some(ver)) =
+                    (&addon.game_compat_name, &addon.game_compat_version)
+                {
+                    ui.label(format!("⛭ {name} ({ver}) Supported"));
                 } else {
                     ui.label("⛭ Unknown Version Supported");
                 }
@@ -195,12 +166,12 @@ impl View for Details {
                     // TODO: pretty print download count
                     ui.label(format!(
                         "⮋ {} Downloads",
-                        addon.to_owned().download_total.unwrap_or("".to_string())
+                        addon.download_total.as_deref().unwrap_or("")
                     ));
                 });
             });
             ui.horizontal(|ui| {
-                let mut version_text = addon.version.to_string();
+                let mut version_text = addon.version.clone();
                 if let Some(ref installed_version) = addon.installed_version
                     && *installed_version != addon.version
                 {
@@ -211,7 +182,7 @@ impl View for Details {
                     // TODO: pretty print favorite count
                     ui.label(format!(
                         "♥ {} Favorites",
-                        addon.to_owned().favorite_total.unwrap_or("".to_string())
+                        addon.favorite_total.as_deref().unwrap_or("")
                     ));
                 });
             });
@@ -240,26 +211,30 @@ impl View for Details {
                     DetailView::ChangeLog,
                     RichText::new("Change Log").heading(),
                 );
-                // ui.checkbox(&mut self.show_raw_text, "Show Unformatted Text");
+                ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
+                    ui.checkbox(&mut self.show_raw_text, "Raw");
+                });
             });
             ui.add_space(5.0);
         });
 
         egui::CentralPanel::default().show(ctx, |ui| {
-            ScrollArea::vertical().show(ui, |ui| match self.view {
+            ScrollArea::vertical()
+                .auto_shrink([false, true])
+                .show(ui, |ui| match self.view {
                 DetailView::Description => {
-                    // if self.parsed_description.is_ready() && !self.show_raw_text {
-                    //     ui_show_bbtree(ui, self.parsed_description.value.as_ref().unwrap());
-                    // } else {
-                    ui.label(addon.description.as_ref().unwrap_or(&"".to_string()));
-                    // }
+                    if self.show_raw_text {
+                        ui.label(addon.description.as_deref().unwrap_or(""));
+                    } else if let Some(view) = &self.bb_description {
+                        view.show(ui, &mut self.bb_description_state, "description");
+                    }
                 }
                 DetailView::ChangeLog => {
-                    // if self.parsed_changelog.is_ready() && !self.show_raw_text {
-                    //     ui_show_bbtree(ui, self.parsed_changelog.value.as_ref().unwrap());
-                    // } else {
-                    ui.label(addon.change_log.as_ref().unwrap_or(&"".to_string()));
-                    // }
+                    if self.show_raw_text {
+                        ui.label(addon.change_log.as_deref().unwrap_or(""));
+                    } else if let Some(view) = &self.bb_changelog {
+                        view.show(ui, &mut self.bb_changelog_state, "change_log");
+                    }
                 }
                 DetailView::Pictures => {
                     if self.selected_image == String::default() {
@@ -299,14 +274,14 @@ impl View for Details {
                         .spacing([40.0, 4.0])
                         .striped(true)
                         .show(ui, |ui| {
-                            if let Some(download) = addon.download {
+                            if let Some(download) = &addon.download {
                                 ui.label("Download Link");
-                                ui.hyperlink_to(truncate_len(&download, 40), download);
+                                ui.hyperlink_to(truncate_len(download, 40), download);
                                 ui.end_row();
                             }
-                            if let Some(md5) = addon.md5 {
+                            if let Some(md5) = &addon.md5 {
                                 ui.label("MD5");
-                                ui.code(md5);
+                                ui.code(md5.as_str());
                                 ui.end_row();
                             }
                         });
@@ -324,5 +299,7 @@ impl ResetView for Details {
         }
         // re-get details for same addon
         self.details.set(service.get_addon_details(self.addon_id));
+        self.bb_description = None;
+        self.bb_changelog = None;
     }
 }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tools"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+bbcode = { path = "../bbcode", version = "0.1" }
+reqwest = { version = "0.12.28", default-features = false, features = [
+    "gzip",
+    "json",
+    "rustls-tls",
+] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+tokio = { version = "1.51.1", features = ["macros", "rt"] }
+
+[[bin]]
+name = "scan_corpus"
+path = "src/bin/scan_corpus.rs"

--- a/tools/src/bin/scan_corpus.rs
+++ b/tools/src/bin/scan_corpus.rs
@@ -1,0 +1,159 @@
+//! Fetch the top-N ESO addon descriptions and report bbcode tag frequency.
+//!
+//! Usage:
+//!   cargo run -p tools --bin scan_corpus
+//!   cargo run -p tools --bin scan_corpus -- 200
+//!
+//! Caches under `<workspace>/target/scan-corpus-cache/`. The filelist refreshes
+//! after 24h; per-addon detail JSON is cached forever (run `cargo clean` to
+//! drop everything).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::Deserialize;
+
+const FILE_LIST_URL: &str = "https://api.mmoui.com/v3/game/ESO/filelist.json";
+const FILE_DETAILS_URL: &str = "https://api.mmoui.com/v3/game/ESO/filedetails/";
+const FILELIST_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[derive(Deserialize)]
+struct FileListItem {
+    #[serde(rename = "UID")]
+    id: String,
+    #[serde(rename = "UIName")]
+    name: String,
+    #[serde(rename = "UIDownloadTotal")]
+    download_total: String,
+}
+
+#[derive(Deserialize)]
+struct FileDetails {
+    #[serde(rename = "UIDescription")]
+    description: String,
+    #[serde(rename = "UIChangeLog")]
+    change_log: String,
+}
+
+fn cache_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .join("target/scan-corpus-cache")
+}
+
+async fn fetch_cached(
+    client: &reqwest::Client,
+    url: &str,
+    path: &Path,
+    ttl: Option<Duration>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let stale = match (path.exists(), ttl) {
+        (false, _) => true,
+        (true, None) => false,
+        (true, Some(ttl)) => path
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.elapsed().ok())
+            .is_none_or(|age| age > ttl),
+    };
+    if stale {
+        eprintln!("fetch {url}");
+        let bytes = client.get(url).send().await?.error_for_status()?.bytes().await?;
+        std::fs::write(path, &bytes)?;
+        return Ok(bytes.to_vec());
+    }
+    Ok(std::fs::read(path)?)
+}
+
+fn count_tags(
+    node: &bbcode::Node<'_>,
+    addon_id: &str,
+    counts: &mut BTreeMap<String, usize>,
+    addons: &mut BTreeMap<String, BTreeSet<String>>,
+    depth: &mut usize,
+    max_depth: &mut usize,
+) {
+    if let bbcode::Node::Element(e) = node {
+        let tag = e.tag.to_ascii_lowercase();
+        *counts.entry(tag.clone()).or_default() += 1;
+        addons.entry(tag).or_default().insert(addon_id.to_string());
+        *depth += 1;
+        *max_depth = (*max_depth).max(*depth);
+        for c in &e.children {
+            count_tags(c, addon_id, counts, addons, depth, max_depth);
+        }
+        *depth -= 1;
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let top_n: usize = std::env::args()
+        .nth(1)
+        .map(|s| s.parse().expect("top-N must be a number"))
+        .unwrap_or(100);
+
+    let cache = cache_dir();
+    let details_dir = cache.join("details");
+    std::fs::create_dir_all(&details_dir)?;
+
+    let client = reqwest::Client::builder()
+        .gzip(true)
+        .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
+        .build()?;
+
+    let list_bytes = fetch_cached(
+        &client,
+        FILE_LIST_URL,
+        &cache.join("filelist.json"),
+        Some(FILELIST_TTL),
+    )
+    .await?;
+    let mut items: Vec<FileListItem> = serde_json::from_slice(&list_bytes)?;
+    items.sort_by(|a, b| {
+        let a: i64 = a.download_total.parse().unwrap_or(0);
+        let b: i64 = b.download_total.parse().unwrap_or(0);
+        b.cmp(&a)
+    });
+    items.truncate(top_n);
+
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut addons: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut total_bytes = 0usize;
+    let mut max_depth = 0usize;
+
+    for (i, item) in items.iter().enumerate() {
+        let url = format!("{FILE_DETAILS_URL}{}.json", item.id);
+        let path = details_dir.join(format!("{}.json", item.id));
+        eprintln!("[{:>3}/{:>3}] {}", i + 1, items.len(), item.name);
+        let bytes = fetch_cached(&client, &url, &path, None).await?;
+        let arr: Vec<FileDetails> = serde_json::from_slice(&bytes)?;
+        let Some(d) = arr.into_iter().next() else {
+            continue;
+        };
+        for src in [&d.description, &d.change_log] {
+            total_bytes += src.len();
+            let doc = bbcode::parse(src);
+            let mut depth = 0usize;
+            for node in &doc.children {
+                count_tags(node, &item.id, &mut counts, &mut addons, &mut depth, &mut max_depth);
+            }
+        }
+    }
+
+    println!();
+    println!("addons:    {}", items.len());
+    println!("text size: {} bytes", total_bytes);
+    println!("max depth: {}", max_depth);
+    println!();
+    let mut by_count: Vec<_> = counts.iter().collect();
+    by_count.sort_by(|a, b| b.1.cmp(a.1));
+    for (tag, hits) in by_count.iter().take(40) {
+        let n_addons = addons.get(*tag).map_or(0, |s| s.len());
+        println!("  {tag:<14} hits={hits:>5}  addons={n_addons:>3}");
+    }
+    Ok(())
+}


### PR DESCRIPTION
Replace bbcode-tagger with two in-tree crates:

- bbcode: tokenizer + tree parser, returns a Document borrowing from the input. Permissive: unknown tags pass through as raw text, so AUI-style markers like [FIX]/[ADD] render as they do on forums.
- bbcode-egui: renders the AST into egui. Supports b/i/u/s, color, size, font, url/email, img (inline, click-to-zoom popup), youtube, list/ul/ol, indent, code, spoiler, blur, quote, and align. URL and image schemes restricted; color values restricted to CSS named + hex.

Wire BBView into the addon details view and restore the "Raw" toggle to fall back to unformatted text.

Add a tools crate with a scan_corpus binary that fetches the top-N addon descriptions and reports bbcode tag frequency, used to validate tag and edge-case coverage.

bbcode-egui additionally has an optional feature that we turn on called "entities" that decodes HTML entities as found in Bandits UI where they have cyrillic links. We do some basic sanitization of naughty Unicode, enough that casual tricks won't make a mess.

Fixes #241
Fixes #419

---

Apologies this diff seems quite large, but the implementations are fairly straightforward and a good chunk is tests.

Advanced UI, inline images (top two images don't render due to an eframe bug that will be fixed in a 0.34 bump):

<img width="1108" height="844" alt="image" src="https://github.com/user-attachments/assets/4807a7ac-c13d-44ea-9727-b1cda3c78065" />


Bandits, including entity decoding for the cyrillic:

<img width="1108" height="844" alt="image" src="https://github.com/user-attachments/assets/60e8bcab-5fb0-46ff-a39d-43dcbf630a4f" />

Click to expand image dialog:

<img width="1108" height="844" alt="image" src="https://github.com/user-attachments/assets/f89d3393-e5cb-4fea-ad02-30bae693be0b" />
