### PR TITLE
Improve view navigation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -290,11 +290,10 @@ impl EamApp {
     // region: View Management
 
     fn handle_addon_selected(&mut self, addon_id: i32) {
-        if self.view == ViewOpt::Details {
-            return;
-        }
         self.details.set_addon(addon_id, &mut self.service);
-        self.change_view(ViewOpt::Details);
+        if self.view != ViewOpt::Details {
+            self.change_view(ViewOpt::Details);
+        }
     }
 
     fn change_view(&mut self, view: ViewOpt) {
@@ -304,8 +303,14 @@ impl EamApp {
     }
 
     fn close_view(&mut self) {
-        // swap back to previous view
-        self.view = self.view_stack.pop().unwrap();
+        let Some(view) = self.view_stack.pop() else {
+            return;
+        };
+        if view == ViewOpt::Root {
+            self.view_stack.push(view);
+            return;
+        }
+        self.view = view;
     }
 
     // endregion
@@ -385,6 +390,10 @@ impl eframe::App for EamApp {
         // gracefully handle app quit
         if ctx.input(|i| i.viewport().close_requested()) {
             self.handle_quit();
+        }
+
+        if ctx.input(|i| i.pointer.button_pressed(egui::PointerButton::Extra1)) {
+            self.close_view();
         }
 
         self.poll();


### PR DESCRIPTION
Wire mouse navigator back button (`PointerButton::Extra1`) to the existing `close_view` action, and make `close_view` safe at the top of the view stack by preserving the `Root` sentinel rather than activating it (which would hit `todo!()` and panic on the next render).

Also let `handle_addon_selected` re-target the Details view when it is already the active view, so clickable addon refs from sibling panels can navigate between addons without first leaving Details.