### PR TITLE
Add errors UI and surface service errors

### DIFF
--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -83,9 +83,10 @@ impl ApiClient {
 
     pub async fn get_file_details(&self, id: i32) -> Result<FileDetails> {
         let req_url = format!("{}{}.json", self.file_details_url, id);
-        let res = self.req_url::<Vec<FileDetails>>(&req_url).await.unwrap();
-        let res = res.first().cloned().unwrap();
-        Ok(res)
+        let res = self.req_url::<Vec<FileDetails>>(&req_url).await?;
+        res.into_iter()
+            .next()
+            .ok_or_else(|| error::Error::ApiEmptyResponse { url: req_url })
     }
 
     pub async fn download_file(&self, url: &str) -> Result<Response> {
@@ -100,24 +101,17 @@ impl ApiClient {
     }
 
     pub async fn get_categories(&self) -> Result<Vec<Category>> {
-        let res = self
-            .req_url::<Vec<Category>>(&self.category_list_url)
-            .await
-            .unwrap();
-        Ok(res)
+        self.req_url::<Vec<Category>>(&self.category_list_url).await
     }
 
     pub async fn get_hm_data(&self, data: String) -> Result<Response> {
         let url = "http://harvestmap.binaryvector.net:8081";
-        let res = self
-            .client
+        self.client
             .post(url)
             .body(data)
             .send()
             .await
             .context(error::ApiGetUrlSnafu { url })
-            .unwrap();
-        Ok(res)
     }
 
     async fn get_game_config(&mut self) -> Result<()> {
@@ -132,17 +126,33 @@ impl ApiClient {
 
     async fn req_url<T: serde::de::DeserializeOwned>(&self, url: &str) -> Result<T> {
         info!("Requesting: {url}");
-        let res = self
+        let bytes = self
             .client
             .get(url)
             .send()
             .await
             .context(error::ApiGetUrlSnafu { url })?
-            .json::<T>()
+            .bytes()
             .await
             .context(error::ApiParseResponseSnafu { url })?;
-        Ok(res)
+
+        if let Ok(err) = serde_json::from_slice::<EsoApiError>(&bytes) {
+            return error::ApiUpstreamSnafu {
+                url,
+                message: err.error,
+            }
+            .fail();
+        }
+
+        serde_json::from_slice(&bytes).context(error::ApiDeserializeSnafu { url })
     }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EsoApiError {
+    #[serde(rename = "ERROR")]
+    error: String,
 }
 
 #[derive(Deserialize)]
@@ -248,12 +258,11 @@ fn convert_date<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s: u64 = Deserialize::deserialize(deserializer)
-        .map_err(D::Error::custom)
-        .unwrap();
-    let datetime =
-        DateTime::from_timestamp_millis(s.try_into().unwrap()).expect("invalid timestamp");
-    Ok(datetime)
+    let s: u64 = Deserialize::deserialize(deserializer)?;
+    let millis: i64 = s
+        .try_into()
+        .map_err(|_| D::Error::custom("timestamp out of range"))?;
+    DateTime::from_timestamp_millis(millis).ok_or_else(|| D::Error::custom("invalid timestamp"))
 }
 
 #[derive(Deserialize)]

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -51,8 +51,17 @@ pub enum Error {
     #[snafu(display("Error parsing response from url {}: {}", url, source))]
     ApiParseResponse { source: reqwest::Error, url: String },
 
-    #[snafu(display("Error deserializing response: {}", source))]
-    ApiDeserialize { source: serde_json::Error },
+    #[snafu(display("Empty response from url {}", url))]
+    ApiEmptyResponse { url: String },
+
+    #[snafu(display("Error deserializing response from url {}: {}", url, source))]
+    ApiDeserialize {
+        source: serde_json::Error,
+        url: String,
+    },
+
+    #[snafu(display("AddOn site returned error '{}' for url {}", message, url))]
+    ApiUpstream { url: String, message: String },
 
     #[snafu(display("Error with addon directory metadata {}: {}", dir.display(), source))]
     AddonDirMetadata { source: io::Error, dir: PathBuf },
@@ -101,6 +110,12 @@ pub enum Error {
 
     #[snafu(display("HarvestMap-Data needs to be installed before updating pin data"))]
     HarvestMapDataNotInstalled,
+
+    #[snafu(display("Addon {} not found", id))]
+    AddonNotFound { id: i32 },
+
+    #[snafu(display("Addon {} has no download URL", id))]
+    AddonMissingDownloadUrl { id: i32 },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{self, BufReader, Read, Seek, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use self::backup::{BackupData, BackupInstalledAddon, BackupManualDependency};
 use self::fs_util::{fs_delete_addon, fs_read_addon};
@@ -32,7 +33,7 @@ use sea_orm::{
     ModelTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, RelationTrait, Set,
     Statement, TransactionTrait,
 };
-use snafu::{ResultExt, ensure};
+use snafu::{OptionExt, ResultExt, ensure};
 use tempfile::NamedTempFile;
 use tracing::log::{self, error, info, warn};
 use version_compare::Version;
@@ -56,6 +57,7 @@ pub struct AddonService {
     pub api: ApiClient,
     pub config: config::Config,
     pub db: DatabaseConnection,
+    pub errors: Arc<Mutex<Vec<ErrorRecord>>>,
 }
 impl AddonService {
     pub async fn new() -> Self {
@@ -93,23 +95,59 @@ impl AddonService {
             api: client,
             config,
             db,
+            errors: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub fn record_error(&self, context: impl Into<String>, message: impl ToString) {
+        let record = ErrorRecord {
+            timestamp: chrono::Utc::now(),
+            context: context.into(),
+            message: message.to_string(),
+        };
+        error!("{}: {}", record.context, record.message);
+        if let Ok(mut errors) = self.errors.lock() {
+            errors.push(record);
+        }
+    }
+
+    pub fn errors(&self) -> Vec<ErrorRecord> {
+        self.errors.lock().map(|e| e.clone()).unwrap_or_default()
+    }
+
+    pub fn clear_errors(&self) {
+        if let Ok(mut errors) = self.errors.lock() {
+            errors.clear();
         }
     }
 
     pub fn install(&self, addon_id: i32, update: bool) -> ImmediateValuePromise<()> {
         let service = self.clone();
         ImmediateValuePromise::new(async move {
-            service.p_install(addon_id, update).await.unwrap();
+            if let Err(e) = service.p_install(addon_id, update).await {
+                let action = if update { "updating" } else { "installing" };
+                let label = service.addon_label(addon_id).await;
+                service.record_error(format!("Error {action} {label}"), e);
+            }
             Ok(())
         })
     }
+
+    /// Best-effort human-readable label for an addon, e.g. "NinjaWicca UI (#4551)".
+    /// Falls back to "addon {id}" when the name can't be looked up.
+    async fn addon_label(&self, addon_id: i32) -> String {
+        match DbAddon::Entity::find_by_id(addon_id).one(&self.db).await {
+            Ok(Some(a)) => format!("{} (#{addon_id})", a.name),
+            _ => format!("addon {addon_id}"),
+        }
+    }
     async fn p_install(&self, addon_id: i32, update: bool) -> Result<()> {
-        self.p_update_addon_details(addon_id).await.unwrap();
+        self.p_update_addon_details(addon_id).await?;
         let entry = DbAddon::Entity::find_by_id(addon_id)
             .one(&self.db)
             .await
             .context(error::DbGetSnafu)?;
-        let entry = entry.unwrap();
+        let entry = entry.context(error::AddonNotFoundSnafu { id: addon_id })?;
         let installed_entry = InstalledAddon::Entity::find_by_id(addon_id)
             .one(&self.db)
             .await
@@ -129,9 +167,11 @@ impl AddonService {
             info!("Installing addon: {addon_id}");
         }
 
-        let installed = self
-            .fs_download_addon(entry.download.as_ref().unwrap().as_str(), entry.md5)
-            .await?;
+        let download = entry
+            .download
+            .clone()
+            .context(error::AddonMissingDownloadUrlSnafu { id: addon_id })?;
+        let installed = self.fs_download_addon(&download, entry.md5).await?;
         let installed_entry = InstalledAddon::ActiveModel {
             addon_id: ActiveValue::Set(addon_id),
             version: ActiveValue::Set(entry.version.to_string()),
@@ -219,7 +259,7 @@ impl AddonService {
             service.update_categories().await?;
 
             // update addons
-            let file_list = service.api.get_file_list().await.unwrap();
+            let file_list = service.api.get_file_list().await?;
 
             let mut insert_addons = vec![];
             let mut insert_addon_dirs = vec![];
@@ -227,7 +267,13 @@ impl AddonService {
             let mut insert_imgs = vec![];
             let mut addon_ids = vec![];
             for list_item in file_list.iter() {
-                let addon_id: i32 = list_item.id.parse().unwrap();
+                let addon_id: i32 = match list_item.id.parse() {
+                    Ok(id) => id,
+                    Err(e) => {
+                        warn!("Skipping addon with non-integer id {:?}: {e}", list_item.id);
+                        continue;
+                    }
+                };
                 addon_ids.push(addon_id);
                 let addon = DbAddon::ActiveModel {
                     id: ActiveValue::Set(addon_id),
@@ -246,7 +292,7 @@ impl AddonService {
                 // AddOn Directories
                 for addon_dir in list_item.directories.iter() {
                     let addon_dir_model = AddonDir::ActiveModel {
-                        addon_id: ActiveValue::Set(addon.id.to_owned().unwrap()),
+                        addon_id: ActiveValue::Set(addon_id),
                         dir: ActiveValue::Set(addon_dir.to_string()),
                     };
                     insert_addon_dirs.push(addon_dir_model);
@@ -255,9 +301,15 @@ impl AddonService {
                 // Game Compatibilty
                 if let Some(compats) = &list_item.compatibility {
                     for (index, item) in compats.iter().enumerate() {
+                        let Ok(idx) = index.try_into() else {
+                            warn!(
+                                "Skipping compat entry {index} for addon {addon_id} (index out of range)"
+                            );
+                            continue;
+                        };
                         insert_compats.push(GameCompat::ActiveModel {
-                            addon_id: ActiveValue::Set(addon.id.to_owned().unwrap()),
-                            id: ActiveValue::Set(index.try_into().unwrap()),
+                            addon_id: ActiveValue::Set(addon_id),
+                            id: ActiveValue::Set(idx),
                             version: ActiveValue::Set(item.version.to_owned()),
                             name: ActiveValue::Set(item.name.to_owned()),
                         });
@@ -269,9 +321,13 @@ impl AddonService {
                 {
                     let it = thumbs.iter().zip(imgs.iter());
                     for (i, (thumb, img)) in it.enumerate() {
+                        let Ok(idx) = i.try_into() else {
+                            warn!("Skipping image {i} for addon {addon_id} (index out of range)");
+                            continue;
+                        };
                         insert_imgs.push(AddonImage::ActiveModel {
-                            addon_id: ActiveValue::Set(addon.id.to_owned().unwrap()),
-                            index: ActiveValue::Set(i.try_into().unwrap()),
+                            addon_id: ActiveValue::Set(addon_id),
+                            index: ActiveValue::Set(idx),
                             thumbnail: ActiveValue::Set(thumb.to_owned()),
                             image: ActiveValue::Set(img.to_owned()),
                         })
@@ -346,7 +402,7 @@ impl AddonService {
 
             let mut result = UpdateResult::default();
             if upgrade_all {
-                result = service.upgrade().await.unwrap();
+                result = service.upgrade().await?;
             }
             Ok(result)
         })
@@ -354,16 +410,17 @@ impl AddonService {
 
     async fn p_update_addon_details(&self, id: i32) -> Result<()> {
         // check addon_detail not present or out of date
-        let addon = DbAddon::Entity::find_by_id(id).one(&self.db).await.unwrap();
+        let addon = DbAddon::Entity::find_by_id(id)
+            .one(&self.db)
+            .await
+            .context(error::DbGetSnafu)?;
         let addon_detail = AddonDetail::Entity::find_by_id(id)
             .one(&self.db)
             .await
-            .unwrap();
-        if addon.is_some()
-            && addon_detail.is_some()
-            && addon.unwrap().version == addon_detail.unwrap().version.unwrap_or_default()
+            .context(error::DbGetSnafu)?;
+        if let (Some(addon), Some(addon_detail)) = (&addon, &addon_detail)
+            && addon.version == addon_detail.version.clone().unwrap_or_default()
         {
-            // no need to update
             return Ok(());
         }
 
@@ -377,8 +434,15 @@ impl AddonService {
             version: ActiveValue::Set(Some(file_details.version)),
         };
 
-        let addon = DbAddon::Entity::find_by_id(id).one(&self.db).await.unwrap();
-        let mut active: DbAddon::ActiveModel = addon.unwrap().into_active_model();
+        let Some(addon) = DbAddon::Entity::find_by_id(id)
+            .one(&self.db)
+            .await
+            .context(error::DbGetSnafu)?
+        else {
+            warn!("No addon found with id {id} when updating details");
+            return Ok(());
+        };
+        let mut active: DbAddon::ActiveModel = addon.into_active_model();
         active.md5 = Set(Some(file_details.md5.to_owned()));
         active.file_name = Set(Some(file_details.file_name.to_owned()));
         active.download = Set(Some(file_details.download_url.to_owned()));
@@ -403,7 +467,10 @@ impl AddonService {
     pub fn update_addon_details(&self, id: i32) -> ImmediateValuePromise<()> {
         let service = self.clone();
         ImmediateValuePromise::new(async move {
-            service.p_update_addon_details(id).await.unwrap();
+            if let Err(e) = service.p_update_addon_details(id).await {
+                let label = service.addon_label(id).await;
+                service.record_error(format!("Error updating details for {label}"), e);
+            }
             Ok(())
         })
     }
@@ -414,18 +481,27 @@ impl AddonService {
         let mut insert_categories = vec![];
         let mut category_parents = vec![];
         for category in categories.iter() {
+            let Ok(cat_id) = category.id.parse() else {
+                warn!("Skipping category with non-integer id {:?}", category.id);
+                continue;
+            };
+            let file_count = category.file_count.parse().ok();
             let db_category = Category::ActiveModel {
-                id: ActiveValue::Set(category.id.parse().unwrap()),
+                id: ActiveValue::Set(cat_id),
                 title: ActiveValue::Set(category.title.to_owned()),
                 icon: ActiveValue::Set(Some(category.icon.to_owned())),
-                file_count: ActiveValue::Set(Some(category.file_count.parse().unwrap())),
+                file_count: ActiveValue::Set(file_count),
             };
             insert_categories.push(db_category);
 
             for parent_id in category.parent_ids.iter() {
+                let Ok(parent) = parent_id.parse() else {
+                    warn!("Skipping non-integer parent id {parent_id:?} for category {cat_id}");
+                    continue;
+                };
                 let db_parent = CategoryParent::ActiveModel {
-                    id: ActiveValue::Set(category.id.parse().unwrap()),
-                    parent_id: ActiveValue::Set(parent_id.parse().unwrap()),
+                    id: ActiveValue::Set(cat_id),
+                    parent_id: ActiveValue::Set(parent),
                 };
                 category_parents.push(db_parent);
             }
@@ -467,32 +543,23 @@ impl AddonService {
         let service = self.clone();
         ImmediateValuePromise::new(async move {
             info!("Removing addon with id: {addon_id}");
-            // check if valid addon ID
-            let addon = DbAddon::Entity::find_by_id(addon_id)
+            let Some(addon) = DbAddon::Entity::find_by_id(addon_id)
                 .one(&service.db)
                 .await
-                .context(error::DbGetSnafu)?;
-            match addon {
-                Some(_) => {}
-                None => {
-                    warn!("Not a valid addon ID!");
-                    return Ok(());
-                }
-            }
-            // check if installed before removing
-            let addon = addon.unwrap();
-            let installed_addon = addon
+                .context(error::DbGetSnafu)?
+            else {
+                warn!("Not a valid addon ID!");
+                return Ok(());
+            };
+            let Some(installed_addon) = addon
                 .find_related(InstalledAddon::Entity)
                 .one(&service.db)
                 .await
-                .context(error::DbGetSnafu)?;
-            match installed_addon {
-                Some(_) => {}
-                None => {
-                    error!("Addon not installed!");
-                    return Ok(());
-                }
-            }
+                .context(error::DbGetSnafu)?
+            else {
+                warn!("Addon not installed!");
+                return Ok(());
+            };
             // get installed dirs
             let installed_dirs = addon
                 .find_related(AddonDir::Entity)
@@ -500,9 +567,7 @@ impl AddonService {
                 .all(&service.db)
                 .await
                 .context(error::DbGetSnafu)?;
-            // delete from installed
             installed_addon
-                .unwrap()
                 .delete(&service.db)
                 .await
                 .context(error::DbDeleteSnafu)?;
@@ -581,7 +646,12 @@ impl AddonService {
             let addon_dirs: Vec<String> = walker
                 .filter_map(|e| e.ok())
                 .filter(|e| e.path().is_dir())
-                .map(|e| e.path().file_name().unwrap().to_str().unwrap().to_string())
+                .filter_map(|e| {
+                    e.path()
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|s| s.to_string())
+                })
                 .collect();
             let mut addon_versions = HashMap::new();
             for addon_dir in addon_dirs {
@@ -597,10 +667,17 @@ impl AddonService {
             let mut manifest_deps: HashMap<String, Vec<String>> = HashMap::new();
             let mut nested_dirs: HashMap<String, Vec<String>> = HashMap::new();
             for entry in walker.filter_map(|e| e.ok()).filter(|e| {
-                e.path().is_file()
-                    && e.path().parent().unwrap().file_name().unwrap()
-                        == e.path().file_stem().unwrap()
-                    && ["txt", "addon"].contains(&e.path().extension().unwrap().to_str().unwrap())
+                let path = e.path();
+                let Some(parent_name) = path.parent().and_then(|p| p.file_name()) else {
+                    return false;
+                };
+                let Some(stem) = path.file_stem() else {
+                    return false;
+                };
+                let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+                    return false;
+                };
+                path.is_file() && parent_name == stem && ["txt", "addon"].contains(&ext)
             }) {
                 let parent = entry
                     .path()
@@ -625,7 +702,11 @@ impl AddonService {
                 else {
                     continue;
                 };
-                let manifest = match parser.parse(entry.path().to_str().unwrap(), None) {
+                let Some(path_str) = entry.path().to_str() else {
+                    warn!("Skipping non-UTF-8 manifest path {:?}", entry.path());
+                    continue;
+                };
+                let manifest = match parser.parse(path_str, None) {
                     Ok(manifest) => manifest,
                     Err(err) => {
                         warn!("{}", err);
@@ -638,12 +719,14 @@ impl AddonService {
                     continue;
                 }
                 let new_version = manifest.version.unwrap_or("0".to_string());
-                // only update to the newest found version
-                if let Some(version) = addon_versions.get(&manifest.title)
-                    && Version::from(version).unwrap()
-                        < Version::from(&new_version).unwrap_or(Version::from("0").unwrap())
-                {
-                    addon_versions.insert(manifest.title, new_version);
+                if let Some(version) = addon_versions.get(&manifest.title) {
+                    let current = Version::from(version);
+                    let candidate = Version::from(&new_version);
+                    if let (Some(current), Some(candidate)) = (current, candidate)
+                        && current < candidate
+                    {
+                        addon_versions.insert(manifest.title, new_version);
+                    }
                 }
                 if !manifest.depends_on.is_empty() {
                     manifest_deps.insert(
@@ -689,25 +772,23 @@ where i.addon_id is null
                     keys.iter().map(|k| k.into()).collect::<Vec<_>>(),
                 ))
                 .await
-                .unwrap();
+                .context(error::DbGetSnafu)?;
             let now = format!("{}", chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC"));
-            let inserts: Vec<InstalledAddon::ActiveModel> = db_results
-                .iter()
-                .map(|x| {
-                    let addon_id: i32 = x.try_get_by(0).unwrap();
-                    let dir: String = x.try_get_by(2).unwrap();
-                    InstalledAddon::ActiveModel {
-                        addon_id: ActiveValue::Set(addon_id),
-                        version: ActiveValue::Set(
-                            addon_versions
-                                .get(&dir)
-                                .unwrap_or(&"0".to_string())
-                                .to_string(),
-                        ),
-                        date: ActiveValue::Set(now.to_string()),
-                    }
-                })
-                .collect();
+            let mut inserts: Vec<InstalledAddon::ActiveModel> = Vec::new();
+            for x in db_results.iter() {
+                let addon_id: i32 = x.try_get_by(0).context(error::DbGetSnafu)?;
+                let dir: String = x.try_get_by(2).context(error::DbGetSnafu)?;
+                inserts.push(InstalledAddon::ActiveModel {
+                    addon_id: ActiveValue::Set(addon_id),
+                    version: ActiveValue::Set(
+                        addon_versions
+                            .get(&dir)
+                            .unwrap_or(&"0".to_string())
+                            .to_string(),
+                    ),
+                    date: ActiveValue::Set(now.to_string()),
+                });
+            }
             // 2. insert as installed, update checks will handle the rest
             if !inserts.is_empty() {
                 info!("Adding {} untracked addons", inserts.len());
@@ -866,8 +947,7 @@ where i.addon_id is null
             ))
             .all(&db)
             .await
-            .context(error::DbGetSnafu)
-            .unwrap();
+            .context(error::DbGetSnafu)?;
             Ok(results)
         })
     }
@@ -1152,7 +1232,10 @@ where i.addon_id is null
         let service = self.clone();
         ImmediateValuePromise::new(async move {
             // check if we need to grab it, grab if needed
-            service.p_update_addon_details(addon_id).await.unwrap();
+            if let Err(e) = service.p_update_addon_details(addon_id).await {
+                let label = service.addon_label(addon_id).await;
+                service.record_error(format!("Error updating details for {label}"), e);
+            }
 
             // get the details we need
             info!("Loading addon details for id: {addon_id}");
@@ -1177,8 +1260,7 @@ where i.addon_id is null
                 .into_model::<AddonShowDetails>()
                 .one(&service.db)
                 .await
-                .context(error::DbGetSnafu)
-                .unwrap();
+                .context(error::DbGetSnafu)?;
             if result.is_none() {
                 warn!("No details found for addon: {addon_id}");
             }
@@ -1189,7 +1271,9 @@ where i.addon_id is null
     // region: Config
 
     pub fn save_config(&self) {
-        self.config.save().unwrap();
+        if let Err(e) = self.config.save() {
+            self.record_error("Saving config", e);
+        }
     }
 
     pub fn get_addon_dir(&self) -> PathBuf {
@@ -1204,16 +1288,13 @@ where i.addon_id is null
         path_addr: Option<&str>,
         md5: Option<String>,
     ) -> Result<ZipArchive<File>> {
-        let response = tokio::join!(async move {
-            self.api
-                .download_file(url)
-                .await
-                .unwrap()
-                .bytes()
-                .await
-                .unwrap()
-        })
-        .0;
+        let response = self
+            .api
+            .download_file(url)
+            .await?
+            .bytes()
+            .await
+            .context(error::ApiParseResponseSnafu { url })?;
 
         let mut tmpfile = NamedTempFile::new().context(error::AddonDownloadTmpFileSnafu)?;
         let mut r_tmpfile = tmpfile
@@ -1222,7 +1303,9 @@ where i.addon_id is null
         tmpfile
             .write_all(response.as_ref())
             .context(error::AddonDownloadTmpFileWriteSnafu)?;
-        r_tmpfile.rewind().unwrap();
+        r_tmpfile
+            .rewind()
+            .context(error::AddonDownloadTmpFileReadSnafu)?;
 
         // check hash if present
         if let Some(md5) = md5
@@ -1232,7 +1315,9 @@ where i.addon_id is null
             let mut reader = BufReader::new(&r_tmpfile);
             let mut buffer = [0; 8192];
             loop {
-                let bytes_read = reader.read(&mut buffer).unwrap();
+                let bytes_read = reader
+                    .read(&mut buffer)
+                    .context(error::AddonDownloadTmpFileReadSnafu)?;
                 if bytes_read == 0 {
                     break;
                 }
@@ -1246,7 +1331,9 @@ where i.addon_id is null
             if md5 != hash_string {
                 warn!("Expected file hash {md5}, got {hash_string}");
             }
-            r_tmpfile.rewind().unwrap();
+            r_tmpfile
+                .rewind()
+                .context(error::AddonDownloadTmpFileReadSnafu)?;
         }
 
         let mut archive =
@@ -1301,9 +1388,7 @@ where i.addon_id is null
         let addon_name = get_root_dir(&addon_name.mangled_name());
         addon_path.push(addon_name);
 
-        let addon = fs_read_addon(&addon_path);
-
-        Ok(addon.unwrap())
+        fs_read_addon(&addon_path)
     }
 
     pub fn update_ttc_pricetable(&self) -> ImmediateValuePromise<()> {
@@ -1335,19 +1420,25 @@ where i.addon_id is null
         let filepath = file.to_path_buf();
 
         ImmediateValuePromise::new(async move {
-            // Update should already be called on app init, so main addon table should be populated
-            // If called on a new database, the main addon table will be empty. As a workaround, call `update()`.
-            // self.update(false).await.unwrap();
-
-            let line = fs::read_to_string(filepath).unwrap();
-            let ids: Vec<i32> = line
-                .split(',')
-                .filter(|&x| !x.is_empty())
-                .map(|x| x.parse::<i32>().unwrap())
-                .collect();
+            let line = fs::read_to_string(&filepath)?;
+            let mut ids: Vec<i32> = Vec::new();
+            for raw in line.split(',').filter(|x| !x.is_empty()) {
+                match raw.trim().parse::<i32>() {
+                    Ok(id) => ids.push(id),
+                    Err(e) => {
+                        service.record_error(
+                            format!("Importing Minion backup {}", filepath.display()),
+                            format!("Skipping non-integer addon id {raw:?}: {e}"),
+                        );
+                    }
+                }
+            }
             // workaround for weird behavior with promise in promise, slowly install addons one at a time
             for addon_id in ids.iter() {
-                service.p_install(*addon_id, false).await.unwrap();
+                if let Err(e) = service.p_install(*addon_id, false).await {
+                    let label = service.addon_label(*addon_id).await;
+                    service.record_error(format!("Error installing {label}"), e);
+                }
             }
             Ok(())
         })
@@ -1361,15 +1452,13 @@ where i.addon_id is null
                 .into_model::<CategoryResult>()
                 .all(&db)
                 .await
-                .context(error::DbGetSnafu)
-                .unwrap();
+                .context(error::DbGetSnafu)?;
             Ok(categories)
         })
     }
     pub fn get_category_parents(&self) -> ImmediateValuePromise<Vec<ParentCategory>> {
         let db = self.db.clone();
         ImmediateValuePromise::new(async move {
-            // select on Category instead
             let parents = Category::Entity::find()
                 .join_rev(
                     JoinType::InnerJoin,
@@ -1380,8 +1469,7 @@ where i.addon_id is null
                 .group_by(CategoryParent::Column::ParentId)
                 .all(&db)
                 .await
-                .context(error::DbGetSnafu)
-                .unwrap();
+                .context(error::DbGetSnafu)?;
             let mut results: Vec<ParentCategory> = vec![];
             for parent in parents.iter() {
                 let children = Category::Entity::find()
@@ -1393,8 +1481,7 @@ where i.addon_id is null
                     .order_by_asc(Category::Column::Id)
                     .all(&db)
                     .await
-                    .context(error::DbGetSnafu)
-                    .unwrap();
+                    .context(error::DbGetSnafu)?;
                 results.push(ParentCategory {
                     id: parent.id,
                     title: parent.title.to_string(),
@@ -1436,9 +1523,7 @@ where i.addon_id is null
                 .into_model::<AddonShowDetails>()
                 .all(&db)
                 .await
-                .context(error::DbGetSnafu)
-                .unwrap();
-            // addons.truncate(100);
+                .context(error::DbGetSnafu)?;
             Ok(addons)
         })
     }
@@ -1460,7 +1545,10 @@ where i.addon_id is null
                     // if it's in the options, it means not installed
                     if dep_opt.options.contains_key(&satisfied_by) {
                         // install addon
-                        service.p_install(satisfied_by, false).await.unwrap();
+                        if let Err(e) = service.p_install(satisfied_by, false).await {
+                            let label = service.addon_label(satisfied_by).await;
+                            service.record_error(format!("Error installing {label}"), e);
+                        }
                     }
                     dep_insert.satisfied_by = ActiveValue::Set(Some(satisfied_by));
                 }
@@ -1498,7 +1586,7 @@ where i.addon_id is null
                 .context(error::DbGetSnafu)?;
             ensure!(hmd_addon.is_some(), error::HarvestMapDataNotInstalledSnafu);
 
-            let base_dir = config.addon_dir.parent().unwrap();
+            let base_dir = config.addon_dir.parent().unwrap_or(&config.addon_dir);
             let saved_var_dir = base_dir.join("SavedVariables");
             let addon_dir = config.addon_dir.join("HarvestMapData");
             let mut empty_file = addon_dir.join("Main");
@@ -1514,33 +1602,30 @@ where i.addon_id is null
                 let sv_fn1 = saved_var_dir.join(file_name.clone());
                 let sv_fn2 = saved_var_dir.join(format!("{file_name}~"));
 
-                // if save var file exists, create backup...
                 if sv_fn1.exists() {
                     fs::copy(sv_fn1, sv_fn2.clone())?;
                 } else {
-                    // ... else, use empty table to create a placeholder
                     let file_data = format!("Harvest{zone}_SavedVars{}", empty_file_data.as_str());
                     let mut output = File::create(sv_fn2.clone())?;
                     write!(output, "{file_data}")?;
                 }
 
-                let sv_fn2_data = fs::read_to_string(sv_fn2).unwrap();
-                let response = api.get_hm_data(sv_fn2_data).await.unwrap();
+                let sv_fn2_data = fs::read_to_string(sv_fn2)?;
+                let response = api.get_hm_data(sv_fn2_data).await?;
 
                 let mut out_file = addon_dir.join("Modules");
                 out_file.push(format!("HarvestMap{zone}"));
                 if !out_file.exists() {
-                    fs::create_dir(out_file.clone()).unwrap();
+                    fs::create_dir(out_file.clone())?;
                 }
                 out_file.push(file_name);
-                // Write to a temp file in the same directory, streaming the response
-                // body as it arrives, then atomically rename into place so the game
-                // never reads a partially-written file.
                 let out_dir = out_file.parent().unwrap();
                 let mut tmp = NamedTempFile::new_in(out_dir)?;
                 let mut stream = response.bytes_stream();
                 while let Some(chunk) = stream.next().await {
-                    tmp.write_all(&chunk.unwrap())?;
+                    let chunk =
+                        chunk.context(error::ApiParseResponseSnafu { url: "harvestmap" })?;
+                    tmp.write_all(&chunk)?;
                 }
                 tmp.persist(&out_file)
                     .map_err(|e| e.error)
@@ -1710,10 +1795,7 @@ async fn resolve_dirs_to_addons<C: ConnectionTrait>(
 /// sea_orm now returns DbErr::RecordNotInserted when no inserts
 fn check_db_result<T>(result: Result<T, DbErr>) -> Result<()> {
     match result {
-        Ok(r) => Ok(Some(r)),
-        Err(DbErr::RecordNotInserted) => Ok(None),
-        Err(e) => Err(e),
+        Ok(_) | Err(DbErr::RecordNotInserted) => Ok(()),
+        Err(e) => Err(e).context(error::DbPutSnafu),
     }
-    .unwrap();
-    Ok(())
 }

--- a/core/src/service/result.rs
+++ b/core/src/service/result.rs
@@ -1,8 +1,16 @@
+use chrono::{DateTime, Utc};
 use entity::addon as DbAddon;
 use entity::category::Model as Category;
 use sea_orm::FromQueryResult;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct ErrorRecord {
+    pub timestamp: DateTime<Utc>,
+    pub context: String,
+    pub message: String,
+}
 
 pub type AddonMap = HashMap<i32, String>;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::error;
 use tracing::log::info;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::fmt::writer::MakeWriterExt;
@@ -16,6 +15,7 @@ use views::author::Author;
 
 mod views;
 use views::addon_details::Details;
+use views::errors::Errors;
 use views::installed::Installed;
 use views::missing_deps::MissingDeps;
 use views::onboard::Onboard;
@@ -88,6 +88,7 @@ struct EamApp {
     onboard: Onboard,
     missing_dep: MissingDeps,
     author_view: Author,
+    errors_view: Errors,
     /// Addon Service with async network/DB
     service: AddonService,
     /// Addon management promises
@@ -118,15 +119,14 @@ impl EamApp {
         cc.egui_ctx.set_pixels_per_point(1.0);
 
         // set theme based on save config
-        if service.config.style != config::Style::System {
-            let style = match service.config.style {
-                config::Style::Light => Visuals::light(),
-                config::Style::Dark => Visuals::dark(),
-                config::Style::System => todo!(),
-            };
+        let style = match service.config.style {
+            config::Style::Light => Some(Visuals::light()),
+            config::Style::Dark => Some(Visuals::dark()),
+            config::Style::System => None,
+        };
+        if let Some(visuals) = style {
             cc.egui_ctx.set_global_style(egui::Style {
-                visuals: style,
-                // how URL on hyperlink hover
+                visuals,
                 url_in_tooltip: true,
                 ..egui::Style::default()
             });
@@ -144,6 +144,7 @@ impl EamApp {
             onboard: Onboard::default(),
             missing_dep: MissingDeps::new(),
             author_view: Author::default(),
+            errors_view: Errors::default(),
             remove: PromisedValue::default(),
             update_one: HashMap::new(),
             install_one: HashMap::new(),
@@ -176,13 +177,15 @@ impl EamApp {
         // track if any addons have changed so we can notify other views
         let mut addons_changed = false;
 
-        self.update.poll();
+        self.update
+            .poll_recording(&self.service, "Checking for addon updates");
         if self.update.is_ready() && !self.installed_addons.is_polling() {
             self.update.handle();
             info!("Updated addon list.");
             self.get_installed_addons();
         }
-        self.ttc_pricetable.poll();
+        self.ttc_pricetable
+            .poll_recording(&self.service, "Updating TTC PriceTable");
         if self.ttc_pricetable.is_ready() {
             info!("Updated TTC PriceTable.");
             self.ttc_pricetable.handle();
@@ -195,20 +198,19 @@ impl EamApp {
                     info!("Updated HarvestMap data.");
                     self.hm_data = None;
                 }
-                ImmediateValueState::Error(_) => {
-                    // TODO: handle errors better
-                    error!("HM error!");
+                ImmediateValueState::Error(e) => {
+                    self.service.record_error("Updating HarvestMap data", &**e);
                     self.hm_data = None;
                 }
-                ImmediateValueState::Empty => todo!(),
+                ImmediateValueState::Empty => {
+                    self.hm_data = None;
+                }
             }
         }
-        // if self.hm_data.is_ready() {
-        //     self.hm_data.handle();
-        // }
 
         if self.update_one.is_empty() {
-            self.installed_addons.poll();
+            self.installed_addons
+                .poll_recording(&self.service, "Loading installed addons");
         }
         if self.installed_addons.is_ready() {
             self.installed_addons.handle();
@@ -219,7 +221,8 @@ impl EamApp {
                 .displayed_addons(self.installed_addons.value.as_ref().unwrap().to_owned());
         }
 
-        self.missing_deps.poll();
+        self.missing_deps
+            .poll_recording(&self.service, "Checking missing dependencies");
         if self.missing_deps.is_ready() {
             self.missing_deps.handle();
             let has_missing = !self.missing_deps.value.as_ref().unwrap().is_empty();
@@ -243,14 +246,15 @@ impl EamApp {
         }
 
         // poll installing missing dependencies
-        self.install_missing_deps.poll();
+        self.install_missing_deps
+            .poll_recording(&self.service, "Installing missing dependencies");
         if self.install_missing_deps.is_ready() {
             self.install_missing_deps.handle();
             addons_changed = true;
         }
 
         // remove addon poll
-        self.remove.poll();
+        self.remove.poll_recording(&self.service, "Removing addon");
         if self.remove.is_ready() {
             self.remove.handle();
             addons_changed = true;
@@ -259,7 +263,7 @@ impl EamApp {
         // update addons poll
         let mut updated_addons = vec![];
         for (addon_id, promise) in self.update_one.iter_mut() {
-            promise.poll();
+            promise.poll_recording(&self.service, &format!("Updating addon {addon_id}"));
             if promise.is_ready() {
                 updated_addons.push(addon_id.to_owned());
                 promise.handle();
@@ -267,7 +271,6 @@ impl EamApp {
                 info!("Updated addon: {addon_id}");
             }
         }
-        // let fetch_addons = !updated_addons.is_empty();
         for addon_id in updated_addons.iter() {
             self.update_one.remove(addon_id);
         }
@@ -275,14 +278,13 @@ impl EamApp {
         // install addons poll
         let mut installed_addons = vec![];
         for (addon_id, promise) in self.install_one.iter_mut() {
-            promise.poll();
+            promise.poll_recording(&self.service, &format!("Installing addon {addon_id}"));
             if promise.is_ready() {
                 installed_addons.push(addon_id.to_owned());
                 promise.handle();
                 addons_changed = true;
             }
         }
-        // let fetch_addons = !installed_addons.is_empty();
         for addon_id in installed_addons.iter() {
             self.install_one.remove(addon_id);
         }
@@ -461,6 +463,14 @@ impl eframe::App for EamApp {
                         ViewOpt::Settings,
                         RichText::new("⛭ Settings").heading(),
                     );
+                    let error_count = self.service.errors().len();
+                    if error_count > 0 {
+                        ui.selectable_value(
+                            &mut self.view,
+                            ViewOpt::Errors,
+                            RichText::new(format!("⚠ Errors ({error_count})")).heading(),
+                        );
+                    }
                     ui.selectable_value(
                         &mut self.view,
                         ViewOpt::Quit,
@@ -523,9 +533,10 @@ impl eframe::App for EamApp {
                 }
                 ViewOpt::Author => self.author_view.ui(ctx, ui, &mut self.service),
                 ViewOpt::MissingDeps => self.missing_dep.ui(ctx, ui, &mut self.service),
+                ViewOpt::Errors => self.errors_view.ui(ctx, ui, &mut self.service),
                 ViewOpt::Root => {
-                    // should not be reachable with defaults
-                    todo!();
+                    self.view = ViewOpt::Installed;
+                    AddonResponse::default()
                 }
             };
 

--- a/src/views/addon_details.rs
+++ b/src/views/addon_details.rs
@@ -50,17 +50,20 @@ pub struct Details {
 
 impl Details {
     fn poll(&mut self, service: &mut AddonService) {
-        self.details.poll();
+        self.details
+            .poll_recording(service, "Loading addon details");
         if self.details.is_ready() {
             self.details.handle();
             self.build_bb_views();
         }
-        self.images.poll();
-        self.dep_view.poll();
+        self.images.poll_recording(service, "Loading addon images");
+        self.dep_view
+            .poll_recording(service, "Loading addon dependencies");
         if self.dep_view.is_ready() {
             self.dep_view.handle();
         }
-        self.dep_mutation.poll();
+        self.dep_mutation
+            .poll_recording(service, "Updating addon dependencies");
         if self.dep_mutation.is_ready() {
             self.dep_mutation.handle();
             self.dep_view

--- a/src/views/author.rs
+++ b/src/views/author.rs
@@ -15,8 +15,8 @@ impl Author {
         self.author_name = author_name;
         self.get_addons(service);
     }
-    fn poll(&mut self) {
-        self.addons.poll();
+    fn poll(&mut self, service: &AddonService) {
+        self.addons.poll_recording(service, "Loading author addons");
         if self.addons.is_ready() {
             self.addons.handle();
         }
@@ -31,10 +31,10 @@ impl View for Author {
         &mut self,
         _ctx: &eframe::egui::Context,
         ui: &mut eframe::egui::Ui,
-        _service: &mut AddonService,
+        service: &mut AddonService,
     ) -> AddonResponse {
         let mut response = AddonResponse::default();
-        self.poll();
+        self.poll(service);
 
         if self.addons.is_polling() {
             ui.spinner();

--- a/src/views/errors.rs
+++ b/src/views/errors.rs
@@ -1,0 +1,56 @@
+use eframe::egui::{self, Layout, RichText, ScrollArea};
+use eso_addons_core::service::AddonService;
+
+use super::View;
+use super::ui_helpers::AddonResponse;
+
+#[derive(Default)]
+pub struct Errors {}
+
+impl View for Errors {
+    fn ui(
+        &mut self,
+        _ctx: &egui::Context,
+        ui: &mut egui::Ui,
+        service: &mut AddonService,
+    ) -> AddonResponse {
+        let response = AddonResponse::default();
+        let errors = service.errors();
+
+        ui.horizontal(|ui| {
+            ui.heading(format!("Errors ({})", errors.len()));
+            ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
+                if ui
+                    .add_enabled(!errors.is_empty(), egui::Button::new("Clear"))
+                    .clicked()
+                {
+                    service.clear_errors();
+                }
+            });
+        });
+        ui.separator();
+
+        if errors.is_empty() {
+            ui.label("No errors recorded.");
+            return response;
+        }
+
+        ScrollArea::vertical().show(ui, |ui| {
+            for record in errors.iter().rev() {
+                ui.group(|ui| {
+                    ui.horizontal(|ui| {
+                        ui.label(
+                            RichText::new(record.timestamp.format("%Y-%m-%d %H:%M:%S").to_string())
+                                .monospace()
+                                .weak(),
+                        );
+                        ui.label(RichText::new(&record.context).strong());
+                    });
+                    ui.label(&record.message);
+                });
+            }
+        });
+
+        response
+    }
+}

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -5,6 +5,7 @@ use self::ui_helpers::AddonResponse;
 
 pub mod addon_details;
 pub mod author;
+pub mod errors;
 pub mod installed;
 pub mod missing_deps;
 pub mod onboard;

--- a/src/views/onboard.rs
+++ b/src/views/onboard.rs
@@ -18,7 +18,8 @@ pub struct Onboard {
 impl Onboard {
     fn poll(&mut self, service: &mut AddonService) {
         // poll change addon dir dialog
-        self.addon_dir_dialog.poll();
+        self.addon_dir_dialog
+            .poll_recording(service, "Selecting addon directory");
         if self.addon_dir_dialog.is_ready() {
             self.addon_dir_dialog.handle();
             let value = self.addon_dir_dialog.value.as_ref().unwrap();

--- a/src/views/search.rs
+++ b/src/views/search.rs
@@ -45,8 +45,9 @@ impl Search {
         }
     }
 
-    fn poll(&mut self) {
-        self.get_categories.poll();
+    fn poll(&mut self, service: &AddonService) {
+        self.get_categories
+            .poll_recording(service, "Loading categories");
         if self.get_categories.is_ready() {
             self.get_categories.handle();
             self.categories.clear();
@@ -55,13 +56,14 @@ impl Search {
             }
         }
 
-        self.category_addons.poll();
+        self.category_addons
+            .poll_recording(service, "Loading category addons");
         if self.category_addons.is_ready() {
             self.category_addons.handle();
             self.sort_addons();
         }
 
-        self.results.poll();
+        self.results.poll_recording(service, "Searching addons");
         if self.results.is_ready() {
             self.results.handle();
         }
@@ -159,7 +161,7 @@ impl View for Search {
     ) -> AddonResponse {
         let mut response = AddonResponse::default();
         self.handle_init(service);
-        self.poll();
+        self.poll(service);
 
         if self.get_categories.is_polling() {
             ui.spinner();

--- a/src/views/settings.rs
+++ b/src/views/settings.rs
@@ -34,7 +34,8 @@ impl Settings {
         // poll promises
 
         // poll change addon dir dialog
-        self.addon_dir_dialog.poll();
+        self.addon_dir_dialog
+            .poll_recording(service, "Selecting addon directory");
         if self.addon_dir_dialog.is_ready() {
             self.addon_dir_dialog.handle();
             let value = self.addon_dir_dialog.value.as_ref().unwrap();
@@ -48,22 +49,20 @@ impl Settings {
             }
         }
 
-        // cleared addons
-        if self.clear_addons.is_some() {
-            self.clear_addons.as_mut().unwrap().poll();
-            if self.clear_addons.as_ref().unwrap().is_ready() {
+        if let Some(clear_addons) = self.clear_addons.as_mut() {
+            clear_addons.poll_recording(service, "Clearing installed addons");
+            if clear_addons.is_ready() {
                 self.clear_addons = None;
                 response.response_type = AddonResponseType::AddonsChanged;
             }
         }
 
         // poll minion file dialog
-        self.minion_dialog.poll();
+        self.minion_dialog
+            .poll_recording(service, "Selecting Minion backup file");
         if self.minion_dialog.is_ready() {
             self.minion_dialog.handle();
             let value = self.minion_dialog.value.as_ref().unwrap();
-            // start import process if we got a file
-            // TODO: Consider some path checks here? Maybe not...
             if let Some(path) = value {
                 let mut promise = PromisedValue::<()>::default();
                 promise.set(service.import_minion_file(Path::new(path)));
@@ -71,18 +70,17 @@ impl Settings {
             }
         }
 
-        // poll minion import
-        if self.minion_import.is_some() {
-            self.minion_import.as_mut().unwrap().poll();
-            if self.minion_import.as_ref().unwrap().is_ready() {
-                // clear promise
+        if let Some(minion_import) = self.minion_import.as_mut() {
+            minion_import.poll_recording(service, "Importing Minion backup");
+            if minion_import.is_ready() {
                 self.minion_import = None;
                 response.response_type = AddonResponseType::AddonsChanged;
             }
         }
 
         // poll backup file dialog
-        self.backup_dialog.poll();
+        self.backup_dialog
+            .poll_recording(service, "Selecting backup file");
         if self.backup_dialog.is_ready() {
             self.backup_dialog.handle();
             let value = self.backup_dialog.value.as_ref().unwrap();
@@ -93,16 +91,16 @@ impl Settings {
             }
         }
 
-        // poll backup process
-        if self.backup_process.is_some() {
-            self.backup_process.as_mut().unwrap().poll();
-            if self.backup_process.as_ref().unwrap().is_ready() {
+        if let Some(backup_process) = self.backup_process.as_mut() {
+            backup_process.poll_recording(service, "Backing up addon data");
+            if backup_process.is_ready() {
                 self.backup_process = None;
             }
         }
 
         // poll restore file dialog
-        self.restore_dialog.poll();
+        self.restore_dialog
+            .poll_recording(service, "Selecting restore file");
         if self.restore_dialog.is_ready() {
             self.restore_dialog.handle();
             let value = self.restore_dialog.value.as_ref().unwrap();
@@ -113,12 +111,10 @@ impl Settings {
             }
         }
 
-        // poll restore process
-        if self.restore_process.is_some() {
-            self.restore_process.as_mut().unwrap().poll();
-            if self.restore_process.as_ref().unwrap().is_ready() {
+        if let Some(restore_process) = self.restore_process.as_mut() {
+            restore_process.poll_recording(service, "Restoring addon data");
+            if restore_process.is_ready() {
                 self.restore_process = None;
-                // addons have changed, notify appropriately
                 response.response_type = AddonResponseType::AddonsChanged;
             }
         }

--- a/src/views/ui_helpers.rs
+++ b/src/views/ui_helpers.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use tracing::log::error;
 
 use eframe::{
     egui::{
@@ -9,6 +8,7 @@ use eframe::{
     },
     epaint::Color32,
 };
+use eso_addons_core::service::AddonService;
 use eso_addons_core::service::result::{AddonShowDetails, MissingDepView};
 use lazy_async_promise::{ImmediateValuePromise, ImmediateValueState};
 use strum_macros::EnumIter;
@@ -51,6 +51,7 @@ pub enum ViewOpt {
     Author,
     Settings,
     Details,
+    Errors,
     Quit,
 }
 
@@ -58,6 +59,7 @@ pub enum ViewOpt {
 pub struct PromisedValue<T: Send + Clone + Default + 'static> {
     promise: Option<ImmediateValuePromise<T>>,
     pub value: Option<T>,
+    error: Option<String>,
     handled: bool,
 }
 impl<T: Send + Clone + Default> PromisedValue<T> {
@@ -66,26 +68,28 @@ impl<T: Send + Clone + Default> PromisedValue<T> {
             return;
         }
         let state = self.promise.as_mut().unwrap().poll_state();
-        // TODO: Strongly consider saving error here if not in progress or success
         match state {
             ImmediateValueState::Success(state) => {
-                self.value = Some(state.clone()); // copy out of promise
+                self.value = Some(state.clone());
                 self.promise = None;
             }
             ImmediateValueState::Error(e) => {
-                error!("Error fetching data: {}", **e);
+                self.error = Some(format!("{}", **e));
                 self.promise = None;
             }
             _ => {}
         }
-        // if let ImmediateValueState::Success(val) = state {
-        //     self.value = Some(val.clone()); // copy out of promise
-        //     self.promise = None;
-        // }
+    }
+    pub fn poll_recording(&mut self, service: &AddonService, context: &str) {
+        self.poll();
+        if let Some(err) = self.error.take() {
+            service.record_error(context.to_string(), err);
+        }
     }
     pub fn set(&mut self, value_promise: ImmediateValuePromise<T>) {
         self.promise = Some(value_promise);
         self.value = None;
+        self.error = None;
         self.handled = false;
     }
     pub fn is_polling(&self) -> bool {


### PR DESCRIPTION
An Errors tab collects every recoverable failure with a timestamp,
context, and message. Panels that previously assumed remote data was
well-formed now degrade to a small inline error string instead of
crashing the addon details view.

PromisedValue captures the error variant of an ImmediateValuePromise
into an Option<String> and a new poll_recording(service, context)
helper writes it to service.record_error. Every view's poll loop is
threaded through this helper so a failed promise leaves the UI in a
visible state instead of a perpetual spinner.

Many .unwrap() calls inside the service futures (DB queries, file IO,
HarvestMap data sync, Minion import, manifest walk, ZIP extract) are
converted to ? so panics in the spawned tokio task become Err results
that PromisedValue can surface. Per-item parse failures inside the
update() and update_categories() loops skip the bad row instead of
killing the whole batch. check_db_result, which previously turned every
DbErr into a panic via a misplaced .unwrap(), now propagates the error.
Two new error variants (AddonNotFound, AddonMissingDownloadUrl) cover
the install path's previously panicking Option unwraps.

The esoui API occasionally returns {"ERROR":"No AddOn found."} for
unknown ids. ApiClient::req_url now probes for that exact shape (with
deny_unknown_fields) and returns a new ApiUpstream { url, message }
variant before attempting typed deserialization, so the user sees the
upstream message verbatim. service::addon_label looks up "Name (#id)"
from the local DB so install/update error reports identify the addon
by name when possible and fall back to the id when not.

Removes todo!() panics in main.rs for ViewOpt::Root, Style::System, and
the empty-promise branch of the HarvestMap poll.

Fixes #109