### PR TITLE
Fix harvest map data fetch & option saves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,6 +1992,7 @@ dependencies = [
  "dirs",
  "entity",
  "eso_addon_manifest",
+ "futures",
  "lazy_async_promise",
  "md-5 0.11.0",
  "migration",
@@ -2240,6 +2241,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -2332,6 +2334,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -4889,6 +4892,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -4908,12 +4912,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.7",
 ]
@@ -6972,6 +6978,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,6 +13,7 @@ dirs = "6.0.0"
 regex = "1.12.3"
 scraper = "0.26.0"
 tempfile = "3.27.0"
+futures = "0.3"
 requestty = "0.6.3"
 colored = "3"
 walkdir = "2"
@@ -21,6 +22,7 @@ reqwest = { version = "0.12.28", default-features = false, features = [
     "gzip",
     "json",
     "rustls-tls",
+    "stream",
 ] }
 tokio = { version = "1.52.2", features = ["full"] }
 snafu = { version = "0.9.0", features = ["backtrace"] }

--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -22,6 +22,7 @@ use entity::installed_addon as InstalledAddon;
 use entity::manual_dependency as ManualDependency;
 use migration::{Condition, Migrator, MigratorTrait};
 
+use futures::StreamExt;
 use lazy_async_promise::ImmediateValuePromise;
 use md5::{Digest, Md5};
 use sea_orm::sea_query::{Expr, OnConflict};
@@ -1119,17 +1120,26 @@ where i.addon_id is null
                 }
 
                 let sv_fn2_data = fs::read_to_string(sv_fn2).unwrap();
-                let result = api.get_hm_data(sv_fn2_data).await.unwrap();
+                let response = api.get_hm_data(sv_fn2_data).await.unwrap();
 
                 let mut out_file = addon_dir.join("Modules");
                 out_file.push(format!("HarvestMap{zone}"));
                 if !out_file.exists() {
-                    // create modules zone dir
                     fs::create_dir(out_file.clone()).unwrap();
                 }
                 out_file.push(file_name);
-                let mut output = File::create(out_file)?;
-                write!(output, "{}", result.text().await.unwrap()).unwrap();
+                // Write to a temp file in the same directory, streaming the response
+                // body as it arrives, then atomically rename into place so the game
+                // never reads a partially-written file.
+                let out_dir = out_file.parent().unwrap();
+                let mut tmp = NamedTempFile::new_in(out_dir)?;
+                let mut stream = response.bytes_stream();
+                while let Some(chunk) = stream.next().await {
+                    tmp.write_all(&chunk.unwrap())?;
+                }
+                tmp.persist(&out_file)
+                    .map_err(|e| e.error)
+                    .context(error::WriteResultSnafu { path: out_file })?;
             }
             info!("Done HarvestMap data!");
             Ok(())

--- a/src/views/settings.rs
+++ b/src/views/settings.rs
@@ -195,30 +195,63 @@ impl View for Settings {
 
             ui.label(RichText::new("Updates").heading());
             ui.add_space(5.0);
+            let mut updates_changed = false;
             ui.horizontal(|ui| {
-                ui.checkbox(&mut service.config.update_on_launch, "Check for addon updates on launch")
+                updates_changed |= ui
+                    .checkbox(
+                        &mut service.config.update_on_launch,
+                        "Check for addon updates on launch",
+                    )
+                    .changed();
             });
             ui.horizontal(|ui| {
-                egui::ComboBox::from_label("TTC Region").selected_text(format!("{:?}", service.config.ttc_region)).show_ui(ui, |ui| {
-                    ui.selectable_value(&mut service.config.ttc_region, config::TTCRegion::NA, "NA");
-                    ui.selectable_value(&mut service.config.ttc_region, config::TTCRegion::EU, "EU");
-                    ui.selectable_value(&mut service.config.ttc_region, config::TTCRegion::ALL, "All");
-                });
+                egui::ComboBox::from_label("TTC Region")
+                    .selected_text(format!("{:?}", service.config.ttc_region))
+                    .show_ui(ui, |ui| {
+                        updates_changed |= ui
+                            .selectable_value(
+                                &mut service.config.ttc_region,
+                                config::TTCRegion::NA,
+                                "NA",
+                            )
+                            .changed();
+                        updates_changed |= ui
+                            .selectable_value(
+                                &mut service.config.ttc_region,
+                                config::TTCRegion::EU,
+                                "EU",
+                            )
+                            .changed();
+                        updates_changed |= ui
+                            .selectable_value(
+                                &mut service.config.ttc_region,
+                                config::TTCRegion::ALL,
+                                "All",
+                            )
+                            .changed();
+                    });
             });
             ui.horizontal(|ui| {
-                ui.checkbox(
-                    &mut service.config.update_ttc_pricetable,
-                    "Update TTC PriceTable",
-                );
+                updates_changed |= ui
+                    .checkbox(
+                        &mut service.config.update_ttc_pricetable,
+                        "Update TTC PriceTable",
+                    )
+                    .changed();
                 ui.label("(requires TamrielTradeCentre to be installed)");
             });
             ui.horizontal(|ui| {
-                ui.checkbox(
-                    &mut service.config.update_hm_data,
-                    "Update HarvestMap data",
-                );
+                updates_changed |= ui
+                    .checkbox(
+                        &mut service.config.update_hm_data,
+                        "Update HarvestMap data",
+                    )
+                    .changed();
                 ui.label("(requires HarvestMap-Data to be installed)");
             });
+            if updates_changed {
+                service.save_config();
+            }
             ui.add_space(5.0);
             ui.separator();
             ui.add_space(5.0);


### PR DESCRIPTION
HarvestMapData contains binary data that needs to be written as such, the downloader was trying to transform the data into UTF-8 and inserting UTF-8 replacement characters.

The checkbox options were not always persisting on toggle, they now persist immediately.