### PR TITLE
.github: modernize and fix workflows

### DIFF
--- a/.github/problem-matchers/clippy.json
+++ b/.github/problem-matchers/clippy.json
@@ -1,0 +1,21 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "clippy",
+            "pattern": [
+                {
+                    "regexp": "^(?:\\x1b\\[[\\d;]+m)*(warning|warn|error)(?:\\x1b\\[[\\d;]+m)*(\\[(.*)\\])?(?:\\x1b\\[[\\d;]+m)*:(?:\\x1b\\[[\\d;]+m)* ([^\\x1b]*)(?:\\x1b\\[[\\d;]+m)*$",
+                    "severity": 1,
+                    "message": 4,
+                    "code": 3
+                },
+                {
+                    "regexp": "^(?:\\x1b\\[[\\d;]+m)*\\s*(?:\\x1b\\[[\\d;]+m)*\\s*--> (?:\\x1b\\[[\\d;]+m)*(.*):(\\d*):(\\d*)(?:\\x1b\\[[\\d;]+m)*$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3
+                }
+            ]
+        }
+    ]
+}

--- a/.github/problem-matchers/rustc.json
+++ b/.github/problem-matchers/rustc.json
@@ -1,0 +1,21 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "rustc",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[[\\d;]+m)*(error|warning)(?:\\x1b\\[[\\d;]+m)*(?:\\[(E?\\d+|[A-Za-z0-9_-]+)\\])?:?(?:\\x1b\\[[\\d;]+m)*:? (.*)$",
+          "severity": 1,
+          "message": 3,
+          "code": 2
+        },
+        {
+          "regexp": "^(?:\\x1b\\[[\\d;]+m)*\\s*--> (.*):(\\d+):(\\d+)(?:\\x1b\\[[\\d;]+m)*$",
+          "file": 1,
+          "line": 2,
+          "column": 3
+        }
+      ]
+    }
+  ]
+}

--- a/.github/problem-matchers/rustfmt.json
+++ b/.github/problem-matchers/rustfmt.json
@@ -1,0 +1,16 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "rustfmt",
+            "severity": "warning",
+            "pattern": [
+                {
+                    "regexp": "^(Diff in (.+))(?: at line |:)(\\d+):$",
+                    "message": 1,
+                    "file": 2,
+                    "line": 3
+                }
+            ]
+        }
+    ]
+}

--- a/.github/problem-matchers/test.json
+++ b/.github/problem-matchers/test.json
@@ -1,0 +1,20 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "rust-test",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[[\\d;]+m)*thread '([^']+)' panicked at '([^']*)', (.*):(\\d+):(\\d+)(?:\\x1b\\[[\\d;]+m)*$",
+          "message": 2,
+          "file": 3,
+          "line": 4,
+          "column": 5
+        },
+        {
+          "regexp": "^(?:\\x1b\\[[\\d;]+m)*test (.+) \\.\\.\\. FAILED(?:\\x1b\\[[\\d;]+m)*$"
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,44 +18,19 @@ jobs:
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
 
-          - build: macos
-            os: macos-latest
-            target: x86_64-apple-darwin
-
           - build: windows
             os: windows-latest
             target: x86_64-pc-windows-msvc
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Install Rust toolchain "${{ matrix.target }}"
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          override: true
-          profile: minimal
-
-      - name: Install packages
-        if: matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install libssl-dev libgtk-3-dev libglib2.0-dev
+        uses: actions/checkout@v6
 
       - name: Build binary "${{ matrix.target }}"
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --verbose --target=${{ matrix.target }}
+        run: cargo build --release --target=${{ matrix.target }}
 
       - name: Test binary "${{ matrix.target }}"
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --verbose --target=${{ matrix.target }}
+        run: cargo test --release --target=${{ matrix.target }}
 
       - name: Rename binary file
         shell: bash
@@ -65,7 +40,7 @@ jobs:
           mv "$origin" "$dest"
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.target }}
           path: ./target/${{ matrix.target }}/release/${{ env.PROJECT_NAME }}-${{ matrix.target }}*
@@ -75,49 +50,72 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
+        uses: actions/checkout@v6
 
       - name: Install packages
         run: |
           sudo apt update
           sudo apt install zsync
-          sudo apt install libssl-dev libgtk-3-dev libglib2.0-dev
-          cargo install --git https://github.com/StratusFearMe21/cargo-appimage.git
+          cargo install cargo-appimage
 
       - name: Install appimagetool
         run: |
-          wget https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage
-          chmod a+x appimagetool-x86_64.AppImage
-          ./appimagetool-x86_64.AppImage --appimage-extract
-          chmod 755 squashfs-root/usr/bin/*
-          sudo mv squashfs-root/usr/bin/* /usr/bin
-          sudo mv squashfs-root/usr/lib/appimagekit /usr/lib/appimagekit
-          sudo chmod 755 /usr/lib/appimagekit/mksquashfs
-          rm -rf squashfs-root/
-          rm appimagetool-x86_64.AppImage
+          curl -LO https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+          install -m 755 appimagetool-x86_64.AppImage /usr/local/bin/appimagetool
+          rm ./appimagetool-x86_64.AppImage
 
       - name: Build binary
-        uses: actions-rs/cargo@v1
-        with:
-          command: appimage
+        run: cargo appimage
+
+      - name: Create .zsync control files
+        run: |
+          shopt -s nullglob
+          for f in ./*.AppImage; do
+            echo "Creating zsync for $f"
+            zsyncmake "$f"
+          done
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
+          name: appimage
           path: |
             ${{ env.PROJECT_NAME }}*.AppImage
             ${{ env.PROJECT_NAME }}*.zsync
 
+  build_macos_universal:
+    name: Build macOS universal
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Ensure macOS Rust targets
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+      - name: Build aarch64
+        run: cargo build --release --target aarch64-apple-darwin
+
+      - name: Build x86_64
+        run: cargo build --release --target x86_64-apple-darwin
+
+      - name: Make universal binary
+        run: |
+          mkdir -p target/universal/release
+          lipo -create \
+            target/aarch64-apple-darwin/release/${{ env.PROJECT_NAME }} \
+            target/x86_64-apple-darwin/release/${{ env.PROJECT_NAME }} \
+            -output target/universal/release/${{ env.PROJECT_NAME }}
+
+      - name: Upload macOS universal
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.PROJECT_NAME }}-macos-universal
+          path: target/universal/release/${{ env.PROJECT_NAME }}
+
   release_and_publish:
     name: Create release and publish
-    needs: build
+    needs: [build, build_appimage, build_macos_universal]
     runs-on: ubuntu-latest
     steps:
       - name: Get the release version from the tag
@@ -125,12 +123,12 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
       - name: Create Release And Publish These Artifacts
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ env.VERSION }}
           files: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,10 @@
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
 
 name: CI
 permissions:
@@ -12,114 +18,50 @@ env:
   RUSTDOCFLAGS: -D warnings
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Install packages
-        run: |
-          sudo apt update
-          sudo apt install libssl-dev libgtk-3-dev
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - uses: actions/checkout@v6
+      - name: Add rustfmt problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/rustfmt.json"
+      - name: Cargo fmt (check)
+        run: cargo fmt --all -- --check
 
   clippy:
-    name: Clippy
+    name: Check & Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: clippy
-      - name: Install packages
-        run: |
-          sudo apt update
-          sudo apt install libssl-dev libgtk-3-dev
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - name: Add clippy problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/clippy.json"
+      - name: Cargo check
+        run: cargo check --workspace --all-targets --all-features
+      - name: Cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - name: Add test problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/test.json"
+      - name: Cargo test
+        run: cargo test --all -- --nocapture
 
   build:
-    runs-on: ubuntu-latest
-
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
-
-      - name: Install packages
-        run: |
-          sudo apt update
-          sudo apt install libssl-dev libgtk-3-dev
-
-      - name: Build
-        run: cargo build --all --release
-
-  build-win:
-    runs-on: windows-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
-
-      - name: Build
-        run: cargo build --all --release
-
-  build-mac:
-    runs-on: macos-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: x86_64-apple-darwin
-          default: true
-          override: true
-
-      - name: Build for mac
-        run: cargo build --all --release
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - name: Add rustc problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/rustc.json"
+      - name: Cargo build (release)
+        run: cargo build --workspace --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/main.rs"
 [package.metadata.appimage]
 auto_link = true
 auto_link_exclude_list = ["libc.so*", "libdl.so*", "libpthread.so*"]
+icon = "data/icon.png"
 args = [
     "-u",
     "gh-releases-zsync|arviceblot|eso-addons|latest|eso-addon-manager-*x86_64.AppImage.zsync",


### PR DESCRIPTION
The actions-rs repositories are all archived/deprecated. We can use the actions provided toolchain for now, saving install time. libssl/libgtk are no longer needed.
Add a test workflow for PRs.
Fix & modernize AppImage workflow.
Make macOS workflow produce a universal binary (arm & x86). Add prettifiers for PR actions.