### PR TITLE
release: musl Linux builds, fix release pipeline asset naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - build: linux
             os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
 
           - build: windows
             os: windows-latest
@@ -25,6 +25,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Install musl toolchain
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt update && sudo apt install -y musl-tools
+
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Build binary "${{ matrix.target }}"
         run: cargo build --release --target=${{ matrix.target }}
@@ -55,7 +62,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt update
-          sudo apt install zsync
+          sudo apt install -y zsync musl-tools
           cargo install cargo-appimage
 
       - name: Install appimagetool
@@ -64,24 +71,28 @@ jobs:
           install -m 755 appimagetool-x86_64.AppImage /usr/local/bin/appimagetool
           rm ./appimagetool-x86_64.AppImage
 
-      - name: Build binary
-        run: cargo appimage
+      - name: Add Rust target
+        run: rustup target add x86_64-unknown-linux-musl
 
-      - name: Create .zsync control files
+      - name: Build binary
+        run: cargo appimage --target=x86_64-unknown-linux-musl
+
+      - name: Rename AppImage to match zsync update pattern
         run: |
-          shopt -s nullglob
-          for f in ./*.AppImage; do
-            echo "Creating zsync for $f"
-            zsyncmake "$f"
-          done
+          VERSION="${GITHUB_REF#refs/tags/}"
+          NEW_NAME="${PROJECT_NAME}-${VERSION}-x86_64.AppImage"
+          cd target/appimage
+          mv "${PROJECT_NAME}.AppImage" "${NEW_NAME}"
+          rm -f "${PROJECT_NAME}.AppImage.zsync"
+          zsyncmake "${NEW_NAME}"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
         with:
           name: appimage
           path: |
-            ${{ env.PROJECT_NAME }}*.AppImage
-            ${{ env.PROJECT_NAME }}*.zsync
+            target/appimage/${{ env.PROJECT_NAME }}-*-x86_64.AppImage
+            target/appimage/${{ env.PROJECT_NAME }}-*-x86_64.AppImage.zsync
 
   build_macos_universal:
     name: Build macOS universal
@@ -105,13 +116,13 @@ jobs:
           lipo -create \
             target/aarch64-apple-darwin/release/${{ env.PROJECT_NAME }} \
             target/x86_64-apple-darwin/release/${{ env.PROJECT_NAME }} \
-            -output target/universal/release/${{ env.PROJECT_NAME }}
+            -output target/universal/release/${{ env.PROJECT_NAME }}-universal-macos
 
       - name: Upload macOS universal
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PROJECT_NAME }}-macos-universal
-          path: target/universal/release/${{ env.PROJECT_NAME }}
+          path: target/universal/release/${{ env.PROJECT_NAME }}-universal-macos
 
   release_and_publish:
     name: Create release and publish

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,7 +1957,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eso-addon-manager"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "bbcode-egui",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eso-addon-manager"
-version = "0.4.20"
+version = "0.4.21"
 authors = ["arviceblot <github@relay.arviceblot.com>"]
 edition = "2024"
 license = "MIT"
@@ -21,9 +21,8 @@ name = "eso-addon-manager"
 path = "src/main.rs"
 
 [package.metadata.appimage]
-auto_link = true
-auto_link_exclude_list = ["libc.so*", "libdl.so*", "libpthread.so*"]
 icon = "data/icon.png"
+desktop_entry = "data/eso-addon-manager.desktop"
 args = [
     "-u",
     "gh-releases-zsync|arviceblot|eso-addons|latest|eso-addon-manager-*x86_64.AppImage.zsync",

--- a/data/eso-addon-manager.desktop
+++ b/data/eso-addon-manager.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=ESO Addon Manager
+Comment=Elder Scrolls Online Addon Manager
+Exec=eso-addon-manager
+Icon=eso-addon-manager
+Categories=Game;Utility;
+StartupWMClass=eso-addon-manager


### PR DESCRIPTION
The new release pipeline worked nicely, but I identified a handful of mostly cosmetic things, which this now addresses.

Pipeline fixes:
- Linux binary: switch x86_64-unknown-linux-gnu → x86_64-unknown-linux-musl. Produces a fully static binary with no glibc version floor; X11/Wayland/GL are dlopen'd at runtime so they still resolve on the user's system. Adds musl-tools (musl-gcc is needed by libsqlite3-sys's bundled C build) and rustup target add.
- AppImage: same musl switch via `cargo appimage --target=...`. ldd reports "not a dynamic executable" so nothing gets bundled into the AppImage.
- AppImage upload path: previously `eso-addon-manager*.AppImage` at the workspace root, which didn't match the actual cargo-appimage output at target/appimage/. Result: v0.4.20's release shipped the .zsync but not the .AppImage. Fixed to target/appimage/...
- AppImage filename: renamed to eso-addon-manager-${version}-x86_64.AppImage to match the zsync update pattern baked into existing AppImages (eso-addon-manager-*x86_64.AppImage.zsync). Existing zsync clients can now resolve updates. The zsync auto-generated by appimagetool embeds the pre-rename AppImage filename in its header, so we regenerate it against the final name (replacing the older workspace-root zsyncmake loop, which ran in the wrong directory anyway).
- macOS universal binary: now named eso-addon-manager-universal-macos instead of the unsuffixed eso-addon-manager.

Packaging:
- Add data/eso-addon-manager.desktop with StartupWMClass=eso-addon-manager, Categories=Game;Utility;, a human-readable Name, and a Comment. Referenced via desktop_entry in [package.metadata.appimage]. Fixes the dock/taskbar double-icon issue (without StartupWMClass, the launcher and the running window get tracked as separate entries).
- Drop auto_link / auto_link_exclude_list — dead config with a static musl binary.

Bump to 0.4.21.