### PR TITLE
Add clear cache button

### DIFF
--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -31,7 +31,7 @@ use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, ConnectOptions, ConnectionTrait,
     DatabaseConnection, DbBackend, DbErr, EntityTrait, FromQueryResult, IntoActiveModel, JoinType,
     ModelTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, RelationTrait, Set,
-    Statement, TransactionTrait,
+    Statement, TransactionTrait, Value,
 };
 use snafu::{OptionExt, ResultExt, ensure};
 use tempfile::NamedTempFile;
@@ -298,7 +298,7 @@ impl AddonService {
                     insert_addon_dirs.push(addon_dir_model);
                 }
 
-                // Game Compatibilty
+                // Game Compatibility
                 if let Some(compats) = &list_item.compatibility {
                     for (index, item) in compats.iter().enumerate() {
                         let Ok(idx) = index.try_into() else {
@@ -420,6 +420,8 @@ impl AddonService {
             .context(error::DbGetSnafu)?;
         if let (Some(addon), Some(addon_detail)) = (&addon, &addon_detail)
             && addon.version == addon_detail.version.clone().unwrap_or_default()
+            && addon.file_name.is_some()
+            && addon.download.is_some()
         {
             return Ok(());
         }
@@ -1757,6 +1759,22 @@ where i.addon_id is null
     }
 
     // endregion
+
+    pub fn clear_cache(&self) -> ImmediateValuePromise<()> {
+        let db = self.db.clone();
+        ImmediateValuePromise::new(async move {
+            // clear download urls
+            DbAddon::Entity::update_many()
+                .col_expr(DbAddon::Column::Md5, Expr::value(Value::String(None)))
+                .col_expr(DbAddon::Column::FileName, Expr::value(Value::String(None)))
+                .col_expr(DbAddon::Column::Download, Expr::value(Value::String(None)))
+                .exec(&db)
+                .await?;
+            // clear addon details
+            AddonDetail::Entity::delete_many().exec(&db).await?;
+            Ok(())
+        })
+    }
 }
 
 async fn resolve_dirs_to_addons<C: ConnectionTrait>(

--- a/src/views/settings.rs
+++ b/src/views/settings.rs
@@ -26,6 +26,8 @@ pub struct Settings {
 
     restore_dialog: PromisedValue<Option<String>>,
     restore_process: Option<PromisedValue<()>>,
+
+    clear_cache: Option<PromisedValue<()>>,
 }
 impl Settings {
     fn poll(&mut self, service: &mut AddonService) -> AddonResponse {
@@ -115,6 +117,14 @@ impl Settings {
             restore_process.poll_recording(service, "Restoring addon data");
             if restore_process.is_ready() {
                 self.restore_process = None;
+                response.response_type = AddonResponseType::AddonsChanged;
+            }
+        }
+
+        if let Some(clear_cache) = self.clear_cache.as_mut() {
+            clear_cache.poll_recording(service, "Clearing cache");
+            if clear_cache.is_ready() {
+                self.clear_cache = None;
                 response.response_type = AddonResponseType::AddonsChanged;
             }
         }
@@ -333,6 +343,15 @@ impl View for Settings {
                 }
                 ui.hyperlink_to("Logs", eso_addons_core::config::Config::default_config_dir().to_string_lossy());
             });
+            ui.add_space(5.0);
+            if self.clear_cache.as_ref().is_some_and(|x| x.is_polling()) {
+                ui.add_enabled(false, egui::Button::new(RichText::new("Clearing...").heading()));
+            }
+            else if ui.button(RichText::new("Clear Cache").heading()).clicked() {
+                let mut promise = PromisedValue::<()>::default();
+                promise.set(service.clear_cache());
+                self.clear_cache = Some(promise);
+            }
             ui.add_space(5.0);
             if let Some(repo) = REPO {
                 ui.hyperlink_to("Report an issue", format!("{repo}/issues"));


### PR DESCRIPTION
Workaround for issues like #442 where updates in versions prior to 0.4.20 caused some cases for addon details to update but addon download url updates to fail.