### PR TITLE
Reduce redundant TTC and HarvestMap update traffic 

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -62,7 +62,9 @@ impl UpdateCommand {
     pub async fn run(&self, service: &mut AddonService) -> Result<()> {
         // Check if only updating PriceTable
         if self.ttc_pricetable {
-            service.update_ttc_pricetable().await?;
+            let update = service.update_ttc_pricetable().await?;
+            service.config.apply_ttc_update(update);
+            service.save_config();
             return Ok(());
         }
 

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -15,6 +15,8 @@ const GLOBAL_CONFIG: &str = "globalconfig.json";
 const GAME_ID: &str = "ESO";
 /// Current configuration for v3 API
 const ENDPOINT_URL: &str = "https://api.mmoui.com/v3";
+/// User-Agent expected by the TamrielTradeCentre upload/version endpoints.
+const TTC_USER_AGENT: &str = "TamrielTradeCentreClient/1.0.0";
 
 #[derive(Debug, Clone)]
 pub struct ApiClient {
@@ -113,6 +115,21 @@ impl ApiClient {
             .context(error::ApiGetUrlSnafu { url })
     }
 
+    pub async fn get_ttc_pricetable_version(&self, domain: &str) -> Result<u64> {
+        let url = format!("https://{domain}/api/GetTradeClientVersion");
+        let resp: TradeClientVersion = self
+            .client
+            .get(&url)
+            .header(reqwest::header::USER_AGENT, TTC_USER_AGENT)
+            .send()
+            .await
+            .context(error::ApiGetUrlSnafu { url: url.as_str() })?
+            .json()
+            .await
+            .context(error::ApiParseResponseSnafu { url: url.as_str() })?;
+        Ok(resp.price_table_version)
+    }
+
     async fn get_game_config(&mut self) -> Result<()> {
         let res = self.req_url::<EsoApiFeeds>(&self.game_config_url).await?;
         self.file_list_url = res.api_feeds.file_list;
@@ -145,6 +162,12 @@ impl ApiClient {
 
         serde_json::from_slice(&bytes).context(error::ApiDeserializeSnafu { url })
     }
+}
+
+#[derive(Deserialize)]
+struct TradeClientVersion {
+    #[serde(rename = "PriceTableVersion")]
+    price_table_version: u64,
 }
 
 #[derive(Deserialize)]

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,7 +1,9 @@
 use crate::error::{self, Result};
+use chrono::{DateTime, Utc};
 use serde::ser::SerializeStruct;
 use serde_derive::{Deserialize, Serialize};
 use snafu::ResultExt;
+use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::path::PathBuf;
 use version_compare::Version;
@@ -32,6 +34,28 @@ pub enum TTCRegion {
     NA,
     EU,
     ALL,
+}
+
+/// Delta of TTC download state produced by a PriceTable update.
+///
+/// The download promise runs on a clone of the service, so it returns this for
+/// the caller to merge into the live config (only `Some` fields are applied);
+/// persisting from inside the clone would be lost on save.
+#[derive(Debug, Clone, Default)]
+pub struct TtcConfigUpdate {
+    pub na_version: Option<u64>,
+    pub eu_version: Option<u64>,
+    pub download_last: Option<DateTime<Utc>>,
+}
+
+/// Delta of HarvestMap sync state produced by a data update.
+///
+/// Like [`TtcConfigUpdate`], the update promise runs on a clone of the service,
+/// so it returns this for the caller to merge into the live config.
+#[derive(Debug, Clone, Default)]
+pub struct HmConfigUpdate {
+    pub zone_hashes: HashMap<String, String>,
+    pub synced_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -79,12 +103,30 @@ pub struct Config {
     pub category_list: String,
     #[serde(default)]
     pub update_ttc_pricetable: bool,
+    /// Last PriceTable version downloaded per region, used to skip redundant
+    /// downloads when the server version is unchanged.
+    #[serde(default)]
+    pub ttc_na_version: Option<u64>,
+    #[serde(default)]
+    pub ttc_eu_version: Option<u64>,
+    #[serde(default)]
+    pub ttc_download_last: Option<DateTime<Utc>>,
     #[serde(default = "default_true")]
     pub update_on_launch: bool,
     #[serde(default = "default_true")]
     pub onboard: bool,
     #[serde(default)]
     pub update_hm_data: bool,
+    /// md5 of the last HarvestMap saved-var data synced per zone, used to skip
+    /// the merge when local data is unchanged.
+    #[serde(default)]
+    pub hm_zone_hashes: HashMap<String, String>,
+    /// Time of the last successful merge per zone, used to force a refresh once
+    /// a zone's data exceeds the max age even if the local data is unchanged.
+    #[serde(default)]
+    pub hm_zone_synced: HashMap<String, DateTime<Utc>>,
+    #[serde(default)]
+    pub hm_last_sync: Option<DateTime<Utc>>,
     #[serde(default)]
     pub style: Style,
     #[serde(default)]
@@ -163,6 +205,28 @@ impl Config {
             .context(error::ConfigWriteFormatSnafu { path: &path })?;
         fs::write(&path, config_str).context(error::ConfigWriteSnafu { path: &path })?;
         Ok(())
+    }
+    pub fn apply_ttc_update(&mut self, update: TtcConfigUpdate) {
+        if update.na_version.is_some() {
+            self.ttc_na_version = update.na_version;
+        }
+        if update.eu_version.is_some() {
+            self.ttc_eu_version = update.eu_version;
+        }
+        if update.download_last.is_some() {
+            self.ttc_download_last = update.download_last;
+        }
+    }
+    pub fn apply_hm_update(&mut self, update: HmConfigUpdate) {
+        for (zone, hash) in update.zone_hashes {
+            if let Some(ts) = update.synced_at {
+                self.hm_zone_synced.insert(zone.clone(), ts);
+            }
+            self.hm_zone_hashes.insert(zone, hash);
+        }
+        if update.synced_at.is_some() {
+            self.hm_last_sync = update.synced_at;
+        }
     }
     pub fn default_config_dir() -> PathBuf {
         dirs::config_dir().unwrap().join(EAM_DATA_DIR)

--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -9,7 +9,7 @@ use self::fs_util::{fs_delete_addon, fs_read_addon};
 use self::result::*;
 use crate::addons::{Addon, get_root_dir};
 use crate::api::ApiClient;
-use crate::config::{self, Config, TTCRegion};
+use crate::config::{self, Config, HmConfigUpdate, TTCRegion, TtcConfigUpdate};
 use crate::error::{self, Result};
 use entity::addon as DbAddon;
 use entity::addon_dependency as AddonDep;
@@ -44,8 +44,8 @@ mod backup;
 mod fs_util;
 pub mod result;
 
-const TTC_URL: &str = "https://us.tamrieltradecentre.com/download/PriceTable";
-const TTC_EU_URL: &str = "https://eu.tamrieltradecentre.com/download/PriceTable";
+const TTC_NA_DOMAIN: &str = "us.tamrieltradecentre.com";
+const TTC_EU_DOMAIN: &str = "eu.tamrieltradecentre.com";
 
 /// Safe upper bound for SQLite bound parameters per statement (SQLITE_MAX_VARIABLE_NUMBER).
 /// Defaults to 32766 on 3.32.0+ (bundled by libsqlite3-sys); 32000 leaves headroom.
@@ -1393,25 +1393,56 @@ where i.addon_id is null
         fs_read_addon(&addon_path)
     }
 
-    pub fn update_ttc_pricetable(&self) -> ImmediateValuePromise<()> {
+    pub fn update_ttc_pricetable(&self) -> ImmediateValuePromise<TtcConfigUpdate> {
         let service = self.clone();
         ImmediateValuePromise::new(async move {
             info!("Updating TTC PriceTable");
-            if service.config.ttc_region == TTCRegion::NA
-                || service.config.ttc_region == TTCRegion::ALL
-            {
-                service
-                    .base_fs_download_extract(TTC_URL, Some("TamrielTradeCentre"), None)
-                    .await?;
+            let mut update = TtcConfigUpdate::default();
+            let region = &service.config.ttc_region;
+
+            let mut targets = vec![];
+            if *region == TTCRegion::NA || *region == TTCRegion::ALL {
+                targets.push((TTC_NA_DOMAIN, service.config.ttc_na_version));
             }
-            if service.config.ttc_region == TTCRegion::EU
-                || service.config.ttc_region == TTCRegion::ALL
-            {
-                service
-                    .base_fs_download_extract(TTC_EU_URL, Some("TamrielTradeCentre"), None)
-                    .await?;
+            if *region == TTCRegion::EU || *region == TTCRegion::ALL {
+                targets.push((TTC_EU_DOMAIN, service.config.ttc_eu_version));
             }
-            Ok(())
+
+            let mut downloaded = false;
+            for (domain, local_version) in targets {
+                // Conditional check: skip download when the server PriceTable
+                // version matches what we last downloaded. Fall back to
+                // downloading if the version can't be fetched.
+                let server_version = match service.api.get_ttc_pricetable_version(domain).await {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        warn!("Could not fetch TTC version for {domain}: {e}; downloading anyway");
+                        None
+                    }
+                };
+                if let (Some(server), Some(local)) = (server_version, local_version)
+                    && server == local
+                {
+                    info!("TTC PriceTable {domain} unchanged (v{server}), skipping download");
+                    continue;
+                }
+
+                let url = format!("https://{domain}/download/PriceTable");
+                service
+                    .base_fs_download_extract(&url, Some("TamrielTradeCentre"), None)
+                    .await?;
+                downloaded = true;
+                if domain == TTC_NA_DOMAIN {
+                    update.na_version = server_version;
+                } else {
+                    update.eu_version = server_version;
+                }
+            }
+
+            if downloaded {
+                update.download_last = Some(chrono::Utc::now());
+            }
+            Ok(update)
         })
     }
 
@@ -1573,7 +1604,7 @@ where i.addon_id is null
         })
     }
 
-    pub fn update_hm_data(&self) -> ImmediateValuePromise<()> {
+    pub fn update_hm_data(&self) -> ImmediateValuePromise<HmConfigUpdate> {
         let db = self.db.clone();
         let config = self.config.clone();
         let api = self.api.clone();
@@ -1596,32 +1627,55 @@ where i.addon_id is null
 
             let empty_file_data = fs::read_to_string(empty_file)?;
 
+            // Refresh a zone at least this often even when local data is
+            // unchanged, so community data does not go stale.
+            let max_age = chrono::Duration::days(1);
+            let now = chrono::Utc::now();
+            let mut update = HmConfigUpdate::default();
+
             // iterate over the different zones
             for zone in ["AD", "EP", "DC", "DLC", "NF"] {
                 let file_name = format!("HarvestMap{zone}.lua");
-                info!("Working on {file_name}...");
 
-                let sv_fn1 = saved_var_dir.join(file_name.clone());
-                let sv_fn2 = saved_var_dir.join(format!("{file_name}~"));
-
-                if sv_fn1.exists() {
-                    fs::copy(sv_fn1, sv_fn2.clone())?;
+                let sv_file = saved_var_dir.join(&file_name);
+                let data = if sv_file.exists() {
+                    fs::read_to_string(&sv_file)?
                 } else {
-                    let file_data = format!("Harvest{zone}_SavedVars{}", empty_file_data.as_str());
-                    let mut output = File::create(sv_fn2.clone())?;
-                    write!(output, "{file_data}")?;
-                }
+                    format!("Harvest{zone}_SavedVars{}", empty_file_data.as_str())
+                };
 
-                let sv_fn2_data = fs::read_to_string(sv_fn2)?;
-                let response = api.get_hm_data(sv_fn2_data).await?;
+                // Hash the local data so we can skip the merge when nothing has
+                // changed since our last sync.
+                let mut hasher = Md5::new();
+                hasher.update(data.as_bytes());
+                let mut hash = String::new();
+                for x in hasher.finalize().iter() {
+                    hash.push_str(format!("{x:02x}").as_str());
+                }
 
                 let mut out_file = addon_dir.join("Modules");
                 out_file.push(format!("HarvestMap{zone}"));
-                if !out_file.exists() {
-                    fs::create_dir(out_file.clone())?;
+                out_file.push(&file_name);
+
+                let fresh = config
+                    .hm_zone_synced
+                    .get(zone)
+                    .is_some_and(|t| now.signed_duration_since(*t) < max_age);
+                if config.hm_zone_hashes.get(zone).map(String::as_str) == Some(hash.as_str())
+                    && out_file.exists()
+                    && fresh
+                {
+                    info!("HarvestMap {zone} unchanged and fresh, skipping");
+                    continue;
                 }
-                out_file.push(file_name);
+
+                info!("Syncing HarvestMap {zone}...");
+                let response = api.get_hm_data(data).await?;
+
                 let out_dir = out_file.parent().unwrap();
+                if !out_dir.exists() {
+                    fs::create_dir_all(out_dir)?;
+                }
                 let mut tmp = NamedTempFile::new_in(out_dir)?;
                 let mut stream = response.bytes_stream();
                 while let Some(chunk) = stream.next().await {
@@ -1632,9 +1686,15 @@ where i.addon_id is null
                 tmp.persist(&out_file)
                     .map_err(|e| e.error)
                     .context(error::WriteResultSnafu { path: out_file })?;
+
+                update.zone_hashes.insert(zone.to_string(), hash);
+            }
+
+            if !update.zone_hashes.is_empty() {
+                update.synced_at = Some(now);
             }
             info!("Done HarvestMap data!");
-            Ok(())
+            Ok(update)
         })
     }
     pub fn get_addons_by_author(

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,8 +97,8 @@ struct EamApp {
     install_one: HashMap<i32, PromisedValue<()>>,
     installed_addons: PromisedValue<Vec<AddonShowDetails>>,
     update: PromisedValue<UpdateResult>,
-    ttc_pricetable: PromisedValue<()>,
-    hm_data: Option<ImmediateValuePromise<()>>,
+    ttc_pricetable: PromisedValue<config::TtcConfigUpdate>,
+    hm_data: Option<ImmediateValuePromise<config::HmConfigUpdate>>,
     missing_deps: PromisedValue<Vec<AddonDepOption>>,
     install_missing_deps: PromisedValue<()>,
     /// Only auto-nav to MissingDeps when newly discovered, not on every refresh.
@@ -188,23 +188,27 @@ impl EamApp {
             .poll_recording(&self.service, "Updating TTC PriceTable");
         if self.ttc_pricetable.is_ready() {
             info!("Updated TTC PriceTable.");
+            if let Some(update) = self.ttc_pricetable.value.take() {
+                self.service.config.apply_ttc_update(update);
+                self.service.save_config();
+            }
             self.ttc_pricetable.handle();
         }
 
-        if let Some(hm_data) = self.hm_data.as_mut() {
+        if let Some(mut hm_data) = self.hm_data.take() {
             match hm_data.poll_state() {
-                ImmediateValueState::Updating => {}
-                ImmediateValueState::Success(_) => {
+                ImmediateValueState::Updating => {
+                    self.hm_data = Some(hm_data);
+                }
+                ImmediateValueState::Success(update) => {
                     info!("Updated HarvestMap data.");
-                    self.hm_data = None;
+                    self.service.config.apply_hm_update(update.clone());
+                    self.service.save_config();
                 }
                 ImmediateValueState::Error(e) => {
                     self.service.record_error("Updating HarvestMap data", &**e);
-                    self.hm_data = None;
                 }
-                ImmediateValueState::Empty => {
-                    self.hm_data = None;
-                }
+                ImmediateValueState::Empty => {}
             }
         }
 

--- a/src/views/settings.rs
+++ b/src/views/settings.rs
@@ -263,6 +263,12 @@ impl View for Settings {
             if service.config.update_ttc_pricetable && !ttc_installed {
                 install_warning(ui, &mut response, "TamrielTradeCentre", TTC_ADDON_ID);
             }
+            if let Some(last) = service.config.ttc_download_last {
+                ui.weak(format!(
+                    "Last PriceTable download: {}",
+                    last.format("%Y-%m-%d %H:%M UTC")
+                ));
+            }
             ui.horizontal(|ui| {
                 updates_changed |= ui
                     .checkbox(
@@ -274,6 +280,12 @@ impl View for Settings {
             });
             if service.config.update_hm_data && !hm_installed {
                 install_warning(ui, &mut response, "HarvestMap-Data", HM_DATA_ADDON_ID);
+            }
+            if let Some(last) = service.config.hm_last_sync {
+                ui.weak(format!(
+                    "Last HarvestMap sync: {}",
+                    last.format("%Y-%m-%d %H:%M UTC")
+                ));
             }
             if updates_changed {
                 service.save_config();


### PR DESCRIPTION
Both the TTC PriceTable download and the HarvestMap data merge ran in
full on every launch. Add change detection so each only does work when
something has actually changed.

TTC PriceTable: query the GetTradeClientVersion API and compare the
server PriceTableVersion against the last version downloaded per region
(NA/EU); skip the download when unchanged, falling back to downloading
if the version can't be fetched.

HarvestMap: hash each zone's local saved-var data and skip the merge
for zones whose data is unchanged and whose merged output already
exists, with a one-day max age so community data still refreshes.
Because the HarvestMap endpoint couples upload and download in one
request, skipping an unchanged fresh zone also defers pulling other
players' new pins for it until the local data changes or the day
elapses.

Record last-downloaded versions and per-zone sync state/times in
config and surface the last download/sync timestamps in Settings.
Update promises run on a service clone, so they return a config delta
the caller merges into the live config to avoid being overwritten on
save.

(Note: stacked atop #463)