### PR TITLE
Fix AppImage launch crash with glibc zigbuild + headless smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
 name: Create Release
 env:
   PROJECT_NAME: eso-addon-manager
+  # glibc floor for Linux builds; 2.28 covers RHEL 8, Debian 10+, Ubuntu 18.04+.
+  GLIBC_VERSION: "2.28"
+  ZIGLANG_VERSION: "0.16.0"
 
 jobs:
   build:
@@ -16,7 +19,7 @@ jobs:
         include:
           - build: linux
             os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
+            target: x86_64-unknown-linux-gnu
 
           - build: windows
             os: windows-latest
@@ -26,18 +29,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install musl toolchain
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: sudo apt update && sudo apt install -y musl-tools
+      - name: Install Zig and cargo-zigbuild (Linux)
+        if: matrix.build == 'linux'
+        run: |
+          pip3 install --break-system-packages ziglang==${ZIGLANG_VERSION}
+          cargo install --locked cargo-zigbuild
 
       - name: Add Rust target
         run: rustup target add ${{ matrix.target }}
 
-      - name: Build binary "${{ matrix.target }}"
-        run: cargo build --release --target=${{ matrix.target }}
-
+      # Test before Build so zigbuild is the last to link the binary, keeping the glibc floor.
       - name: Test binary "${{ matrix.target }}"
         run: cargo test --release --target=${{ matrix.target }}
+
+      - name: Build binary "${{ matrix.target }}"
+        if: matrix.build == 'linux'
+        run: cargo zigbuild --release --target=${{ matrix.target }}.${{ env.GLIBC_VERSION }}
+
+      - name: Build binary "${{ matrix.target }}"
+        if: matrix.build != 'linux'
+        run: cargo build --release --target=${{ matrix.target }}
 
       - name: Rename binary file
         shell: bash
@@ -59,40 +70,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install packages
+      - name: Install Zig and cargo-zigbuild
         run: |
-          sudo apt update
-          sudo apt install -y zsync musl-tools
-          cargo install cargo-appimage
+          pip3 install --break-system-packages ziglang==${ZIGLANG_VERSION}
+          cargo install --locked cargo-zigbuild
 
-      - name: Install appimagetool
+      - name: Build AppImage
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: ./scripts/build-appimage.sh
+
+      - name: Smoke test AppImage (X11 and Wayland)
         run: |
-          curl -LO https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
-          install -m 755 appimagetool-x86_64.AppImage /usr/local/bin/appimagetool
-          rm ./appimagetool-x86_64.AppImage
-
-      - name: Add Rust target
-        run: rustup target add x86_64-unknown-linux-musl
-
-      - name: Build binary
-        run: cargo appimage --target=x86_64-unknown-linux-musl
-
-      - name: Rename AppImage to match zsync update pattern
-        run: |
-          VERSION="${GITHUB_REF#refs/tags/}"
-          NEW_NAME="${PROJECT_NAME}-${VERSION}-x86_64.AppImage"
-          cd target/appimage
-          mv "${PROJECT_NAME}.AppImage" "${NEW_NAME}"
-          rm -f "${PROJECT_NAME}.AppImage.zsync"
-          zsyncmake "${NEW_NAME}"
+          ./scripts/smoke-deps.sh
+          ./scripts/smoke-appimage.sh
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
         with:
           name: appimage
           path: |
-            target/appimage/${{ env.PROJECT_NAME }}-*-x86_64.AppImage
-            target/appimage/${{ env.PROJECT_NAME }}-*-x86_64.AppImage.zsync
+            dist/${{ env.PROJECT_NAME }}-*-x86_64.AppImage
+            dist/${{ env.PROJECT_NAME }}-*-x86_64.AppImage.zsync
 
   build_macos_universal:
     name: Build macOS universal

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,7 @@ env:
   PROJECT_NAME: ${{ github.event.repository.name }}
   RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
+  ZIGLANG_VERSION: "0.16.0"
 
 jobs:
   fmt:
@@ -65,3 +66,20 @@ jobs:
         run: echo "::add-matcher::.github/problem-matchers/rustc.json"
       - name: Cargo build (release)
         run: cargo build --workspace --release
+
+  appimage:
+    name: AppImage smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Zig and cargo-zigbuild
+        run: |
+          pip3 install --break-system-packages ziglang==${ZIGLANG_VERSION}
+          cargo install --locked cargo-zigbuild
+      - name: Build AppImage
+        run: ./scripts/build-appimage.sh
+      - name: Smoke test AppImage (X11 and Wayland)
+        run: |
+          ./scripts/smoke-deps.sh
+          ./scripts/smoke-appimage.sh

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ test-addons/
 libs/
 *.AppImage
 *.zsync
+
+# Local release build outputs (scripts/build-appimage.sh)
+/dist/
+/.cache/

--- a/docs/build-appimage.md
+++ b/docs/build-appimage.md
@@ -1,18 +1,38 @@
 # Build AppImage
 
-## 1. Install cargo-appimage
+The AppImage is built with [cargo-zigbuild], which pins a glibc symbol-version
+floor so the binary runs on older distributions while still linking dynamically
+(winit needs `dlopen` for X11/Wayland, which a static build cannot do).
 
-Requires [appimagetool](https://appimage.github.io/appimagetool/)
+## 1. Install dependencies
+
+[appimagetool] is fetched automatically if it is not on `PATH`.
 
 ```shell
-cargo install cargo-appimage
+cargo install --locked cargo-zigbuild
+pip install ziglang   # or install zig from your package manager
 ```
 
 ## 2. Build
 
 ```shell
-cargo appimage
+./scripts/build-appimage.sh
 ```
 
-This creates `target/eso-addon-manager.AppDir`. Then it turns this directory into an AppImage file created in the project root.
+This produces `dist/eso-addon-manager-<version>-x86_64.AppImage` and a matching
+`.zsync`. `<version>` comes from `git describe`; override it, and other settings,
+with environment variables (`VERSION`, `GLIBC_VERSION`, `OUTDIR`, ...) — see the
+top of the script.
 
+## 3. Run
+
+```shell
+./dist/eso-addon-manager-*-x86_64.AppImage
+```
+
+To check it launches headlessly under X11 and Wayland (as CI does), run
+`./scripts/smoke-appimage.sh`. It needs `xvfb` and `weston` on `PATH`; set
+`SMOKE_BACKENDS=x11` to run only one.
+
+[cargo-zigbuild]: https://github.com/rust-cross/cargo-zigbuild
+[appimagetool]: https://appimage.github.io/appimagetool/

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Build the Linux AppImage. VERSION (default: git describe) and GLIBC_VERSION
+# (default: 2.28) may be overridden from the environment.
+set -euo pipefail
+
+BINARY_NAME="eso-addon-manager"
+ARCH="${ARCH:-x86_64}"
+TARGET="${ARCH}-unknown-linux-gnu"
+OUTDIR="dist"
+GLIBC_VERSION="${GLIBC_VERSION:-2.28}"
+VERSION="${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+cargo zigbuild --release --target="${TARGET}.${GLIBC_VERSION}"
+BIN="target/${TARGET}/release/${BINARY_NAME}"
+
+APPIMAGETOOL="$(command -v appimagetool || true)"
+if [ -z "$APPIMAGETOOL" ]; then
+  APPIMAGETOOL="${ROOT}/.cache/appimagetool"
+  if [ ! -x "$APPIMAGETOOL" ]; then
+    mkdir -p "${ROOT}/.cache"
+    curl -fL -o "$APPIMAGETOOL" \
+      "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage"
+    chmod +x "$APPIMAGETOOL"
+  fi
+fi
+
+APPDIR="$(mktemp -d)/AppDir"
+mkdir -p "${APPDIR}/usr/bin"
+cp "$BIN" "${APPDIR}/usr/bin/"
+cp "data/${BINARY_NAME}.desktop" "${APPDIR}/"
+cp "data/icon.png" "${APPDIR}/${BINARY_NAME}.png"
+cat > "${APPDIR}/AppRun" <<EOF
+#!/bin/sh
+HERE="\$(dirname "\$(readlink -f "\$0")")"
+exec "\$HERE/usr/bin/${BINARY_NAME}" "\$@"
+EOF
+chmod +x "${APPDIR}/AppRun"
+
+# appimagetool writes the .zsync into its working directory, so run it from OUTDIR.
+mkdir -p "$OUTDIR"
+cd "$OUTDIR"
+ARCH="$ARCH" APPIMAGE_EXTRACT_AND_RUN=1 "$APPIMAGETOOL" \
+  -u "gh-releases-zsync|arviceblot|eso-addons|latest|${BINARY_NAME}-*${ARCH}.AppImage.zsync" \
+  "$APPDIR" "${BINARY_NAME}-${VERSION}-${ARCH}.AppImage"

--- a/scripts/smoke-appimage.sh
+++ b/scripts/smoke-appimage.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Launch the AppImage headlessly under X11 and Wayland and confirm the GUI comes
+# up. With ESO_ADDONS_SMOKE_TEST set the app prints MARKER once a frame renders
+# (proving the winit/GL init that crashed in #465) and exits 0; an init failure
+# exits non-zero without the marker.
+#
+# Runs in a throwaway HOME with a seeded offline config so the result depends on
+# the artifact, not on local state or network.
+set -euo pipefail
+
+APPIMAGE="${1:-$(ls dist/*-x86_64.AppImage 2>/dev/null | head -1 || true)}"
+if [ -z "$APPIMAGE" ] || [ ! -x "$APPIMAGE" ]; then
+  echo "usage: $0 [path-to-appimage]" >&2
+  exit 1
+fi
+APPIMAGE="$(cd "$(dirname "$APPIMAGE")" && pwd)/$(basename "$APPIMAGE")"
+
+MARKER="eso-addons: smoke test ok"
+
+export APPIMAGE_EXTRACT_AND_RUN=1
+export LIBGL_ALWAYS_SOFTWARE=1
+export GALLIUM_DRIVER=llvmpipe
+export ESO_ADDONS_SMOKE_TEST=1
+
+seed_home() {
+  local home="$1"
+  mkdir -p "$home/.config/eso-addons" "$home/addons"
+  cat > "$home/.config/eso-addons/config.json" <<JSON
+{
+  "addon_dir": "$home/addons",
+  "file_list": "unused",
+  "file_details": "unused",
+  "list_files": "unused",
+  "category_list": "unused",
+  "update_on_launch": false,
+  "onboard": false
+}
+JSON
+}
+
+check() {
+  local label="$1" log="$2" rc="$3"
+  if [ "$rc" -eq 0 ] && grep -qF "$MARKER" "$log"; then
+    echo "[$label] ok"
+    return 0
+  fi
+  echo "[$label] FAILED (exit $rc)"
+  cat "$log"
+  return 1
+}
+
+smoke_x11() {
+  local home log rc=0
+  home="$(mktemp -d)"
+  seed_home "$home"
+  log="$(mktemp)"
+  HOME="$home" XDG_CONFIG_HOME="$home/.config" \
+    timeout 60 env -u WAYLAND_DISPLAY xvfb-run -a -s "-screen 0 1280x800x24" \
+    "$APPIMAGE" >"$log" 2>&1 || rc=$?
+  check x11 "$log" "$rc"
+}
+
+smoke_wayland() {
+  local home log rc=0 runtime wpid i
+  home="$(mktemp -d)"
+  seed_home "$home"
+  runtime="$(mktemp -d)"
+  chmod 700 "$runtime"
+  XDG_RUNTIME_DIR="$runtime" weston --backend=headless-backend.so \
+    --socket=wayland-smoke --idle-time=0 >/tmp/weston-smoke.log 2>&1 &
+  wpid=$!
+  for ((i = 0; i < 50; i++)); do
+    [ -S "$runtime/wayland-smoke" ] && break
+    sleep 0.2
+  done
+  if [ ! -S "$runtime/wayland-smoke" ]; then
+    echo "[wayland] FAILED: weston did not start"
+    cat /tmp/weston-smoke.log
+    kill "$wpid" 2>/dev/null || true
+    return 1
+  fi
+  log="$(mktemp)"
+  HOME="$home" XDG_CONFIG_HOME="$home/.config" XDG_RUNTIME_DIR="$runtime" \
+    WAYLAND_DISPLAY=wayland-smoke timeout 60 env -u DISPLAY \
+    "$APPIMAGE" >"$log" 2>&1 || rc=$?
+  kill "$wpid" 2>/dev/null || true
+  check wayland "$log" "$rc"
+}
+
+rc=0
+for backend in ${SMOKE_BACKENDS:-x11 wayland}; do
+  "smoke_$backend" || rc=1
+done
+exit $rc

--- a/scripts/smoke-deps.sh
+++ b/scripts/smoke-deps.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Install the headless X11/Wayland runtime that smoke-appimage.sh launches
+# against (CI helper; mirrors a common desktop's runtime libraries).
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+  xvfb weston \
+  libgl1-mesa-dri libglx-mesa0 libegl1 libgles2 \
+  libx11-6 libxcursor1 libxrandr2 libxi6 libxext6 libxcb1 libxfixes3 \
+  libxkbcommon0 libxkbcommon-x11-0 \
+  libwayland-client0 libwayland-cursor0 libwayland-egl1

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,9 @@ struct EamApp {
     install_missing_deps: PromisedValue<()>,
     /// Only auto-nav to MissingDeps when newly discovered, not on every refresh.
     had_missing_deps: bool,
+    /// Report once the GUI is up and exit; set by ESO_ADDONS_SMOKE_TEST.
+    smoke_test: bool,
+    smoke_reported: bool,
 }
 
 impl EamApp {
@@ -155,6 +158,8 @@ impl EamApp {
             missing_deps: PromisedValue::default(),
             install_missing_deps: PromisedValue::default(),
             had_missing_deps: false,
+            smoke_test: std::env::var_os("ESO_ADDONS_SMOKE_TEST").is_some(),
+            smoke_reported: false,
         };
         if app.service.config.update_on_launch {
             // check for update on init
@@ -398,6 +403,18 @@ impl eframe::App for EamApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         let ctx = ui.ctx().clone();
         let ctx = &ctx;
+
+        if self.smoke_test {
+            if !self.smoke_reported {
+                use std::io::Write;
+                println!("eso-addons: smoke test ok");
+                let _ = io::stdout().flush();
+                self.smoke_reported = true;
+            }
+            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+            return;
+        }
+
         if ctx.input(|i| i.viewport().close_requested()) {
             self.handle_quit();
         }


### PR DESCRIPTION
The musl switch in #449 produced statically-linked binaries, but winit dlopen's at runtime sometimes — which static musl cannot do — so the AppImage aborted on startup with WinitEventLoop(XNotSupported).

Build Linux artifacts with cargo-zigbuild targeting a glibc 2.28 floor instead: dynamically linked (dlopen works) and still portable to older distros (RHEL 8, Debian 10+, Ubuntu 18.04+) without an EOL build image.

- Move AppImage build into scripts/build-appimage.sh, runnable in CI and locally; release.yml drives it instead of cargo-appimage.
- Add a headless smoke test (X11 + Wayland) gated by ESO_ADDONS_SMOKE_TEST: the app reports once the GUI is up and exits, so a failed winit/GL init fails CI. Runs at release time and on PRs.
- docs: update build instructions.

Fixes #465