### PR TITLE
Refresh missing dependencies panel after addon changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,7 +1933,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "eso-addon-manager"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "bbcode-egui",
  "dotenv",

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,22 +236,24 @@ impl EamApp {
             .poll_recording(&self.service, "Checking missing dependencies");
         if self.missing_deps.is_ready() {
             self.missing_deps.handle();
-            let has_missing = !self.missing_deps.value.as_ref().unwrap().is_empty();
+            let deps = self.missing_deps.value.as_ref().unwrap().to_owned();
+            let has_missing = !deps.is_empty();
+            self.missing_dep.set_addons(
+                self.installed_addons
+                    .value
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .map(|x| (x.id, x.name.to_string()))
+                    .collect(),
+            );
+            self.missing_dep.set_deps(deps);
             if has_missing {
-                self.missing_dep.set_addons(
-                    self.installed_addons
-                        .value
-                        .as_ref()
-                        .unwrap()
-                        .iter()
-                        .map(|x| (x.id, x.name.to_string()))
-                        .collect(),
-                );
-                self.missing_dep
-                    .set_deps(self.missing_deps.value.as_ref().unwrap().to_owned());
                 if !self.had_missing_deps {
                     self.change_view(ViewOpt::MissingDeps);
                 }
+            } else if self.view == ViewOpt::MissingDeps {
+                self.close_view();
             }
             self.had_missing_deps = has_missing;
         }

--- a/src/views/missing_deps.rs
+++ b/src/views/missing_deps.rs
@@ -35,6 +35,7 @@ impl MissingDeps {
     }
 
     pub fn set_deps(&mut self, deps: Vec<AddonDepOption>) {
+        self.missing_deps.clear();
         for dep in deps.iter() {
             let dep_view = match self.missing_deps.entry(dep.missing_dir.clone()) {
                 Entry::Occupied(o) => o.into_mut(),


### PR DESCRIPTION
Fixes #471.

## Problem

The missing dependencies panel was "sticky": uninstalling an addon that had a missing dependency left the dependency showing in the panel.

## Root cause

`MissingDeps::set_deps` merged incoming dependencies into its `HashMap` via `Entry` and never removed entries that were no longer missing. Combined with the poll loop only calling `set_deps` when `has_missing` was true, this meant:

- Uninstalling one of several addons with missing deps left the resolved entry behind (stale merge).
- Resolving the last missing dependency never refreshed the cache at all, so the panel kept rendering old entries.

## Fix

- `set_deps` clears the map before rebuilding it, so it reflects exactly the current query result.
- The poll loop always rebuilds the cache after recomputing missing deps, including the empty case.
- When no missing dependencies remain and the panel is the active view, navigate back automatically.