### PR TITLE
Suppress Windows console window in release builds

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 use dotenv::dotenv;
 use eframe::egui::{self, RichText, Visuals, vec2};
 use eso_addons_core::config;


### PR DESCRIPTION
GUI binaries default to the console subsystem, so launching from Explorer allocates a command window that doubles as the log sink. Link release builds as the windows subsystem to drop it; logs already persist to the rolling file appender. Debug builds keep the console for live logs.