### PR TITLE
Handle multi-directory installed addon packages

### DIFF
--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -777,9 +777,18 @@ where i.addon_id is null
                 .context(error::DbGetSnafu)?;
             let now = format!("{}", chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC"));
             let mut inserts: Vec<InstalledAddon::ActiveModel> = Vec::new();
+            let mut pending_by_addon_id: HashMap<i32, Vec<(String, String)>> = HashMap::new();
+
             for x in db_results.iter() {
                 let addon_id: i32 = x.try_get_by(0).context(error::DbGetSnafu)?;
+                let addon_name: String = x.try_get_by(1).context(error::DbGetSnafu)?;
                 let dir: String = x.try_get_by(2).context(error::DbGetSnafu)?;
+
+                pending_by_addon_id
+                    .entry(addon_id)
+                    .or_default()
+                    .push((addon_name.clone(), dir.clone()));
+
                 inserts.push(InstalledAddon::ActiveModel {
                     addon_id: ActiveValue::Set(addon_id),
                     version: ActiveValue::Set(
@@ -790,6 +799,24 @@ where i.addon_id is null
                     ),
                     date: ActiveValue::Set(now.to_string()),
                 });
+            }
+
+            for (addon_id, matches) in pending_by_addon_id
+                .iter()
+                .filter(|(_, matches)| matches.len() > 1)
+            {
+                warn!(
+                    "Duplicate installed-addon detection candidate for addon_id {}: {} matches",
+                    addon_id,
+                    matches.len()
+                );
+
+                for (addon_name, dir) in matches {
+                    warn!(
+                        "  duplicate candidate addon_id={} name={:?} dir={:?}",
+                        addon_id, addon_name, dir
+                    );
+                }
             }
             // 2. insert as installed, update checks will handle the rest
             if !inserts.is_empty() {

--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -720,14 +720,19 @@ impl AddonService {
                     nested_dirs.entry(top_level).or_default().push(dir_name);
                     continue;
                 }
-                let new_version = manifest.version.unwrap_or("0".to_string());
-                if let Some(version) = addon_versions.get(&manifest.title) {
-                    let current = Version::from(version);
-                    let candidate = Version::from(&new_version);
-                    if let (Some(current), Some(candidate)) = (current, candidate)
-                        && current < candidate
-                    {
-                        addon_versions.insert(manifest.title, new_version);
+                let new_version = manifest.version.unwrap_or_else(|| "0".to_string());
+                if let Some(version) = addon_versions.get(&dir_name) {
+                    let should_update = if version == "0" {
+                        !new_version.trim().is_empty() && new_version != "0"
+                    } else {
+                        match (Version::from(version), Version::from(&new_version)) {
+                            (Some(current), Some(candidate)) => current < candidate,
+                            (None, Some(_)) => true,
+                            _ => false,
+                        }
+                    };
+                    if should_update {
+                        addon_versions.insert(dir_name.clone(), new_version);
                     }
                 }
                 if !manifest.depends_on.is_empty() {
@@ -776,48 +781,52 @@ where i.addon_id is null
                 .await
                 .context(error::DbGetSnafu)?;
             let now = format!("{}", chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC"));
-            let mut inserts: Vec<InstalledAddon::ActiveModel> = Vec::new();
-            let mut pending_by_addon_id: HashMap<i32, Vec<(String, String)>> = HashMap::new();
+            let mut detected_versions: HashMap<i32, String> = HashMap::new();
 
             for x in db_results.iter() {
                 let addon_id: i32 = x.try_get_by(0).context(error::DbGetSnafu)?;
-                let addon_name: String = x.try_get_by(1).context(error::DbGetSnafu)?;
                 let dir: String = x.try_get_by(2).context(error::DbGetSnafu)?;
 
-                pending_by_addon_id
+                let candidate_version = addon_versions
+                    .get(&dir)
+                    .cloned()
+                    .unwrap_or_else(|| "0".to_string());
+
+                let selected_version = detected_versions
                     .entry(addon_id)
-                    .or_default()
-                    .push((addon_name.clone(), dir.clone()));
+                    .or_insert_with(|| "0".to_string());
 
-                inserts.push(InstalledAddon::ActiveModel {
-                    addon_id: ActiveValue::Set(addon_id),
-                    version: ActiveValue::Set(
-                        addon_versions
-                            .get(&dir)
-                            .unwrap_or(&"0".to_string())
-                            .to_string(),
-                    ),
-                    date: ActiveValue::Set(now.to_string()),
-                });
-            }
+                if candidate_version.trim().is_empty() || candidate_version == "0" {
+                    continue;
+                }
 
-            for (addon_id, matches) in pending_by_addon_id
-                .iter()
-                .filter(|(_, matches)| matches.len() > 1)
-            {
-                warn!(
-                    "Duplicate installed-addon detection candidate for addon_id {}: {} matches",
-                    addon_id,
-                    matches.len()
-                );
+                let should_update = if selected_version == "0" {
+                    true
+                } else {
+                    match (
+                        Version::from(&*selected_version),
+                        Version::from(&candidate_version),
+                    ) {
+                        (Some(current), Some(candidate)) => current < candidate,
+                        (None, Some(_)) => true,
+                        _ => false,
+                    }
+                };
 
-                for (addon_name, dir) in matches {
-                    warn!(
-                        "  duplicate candidate addon_id={} name={:?} dir={:?}",
-                        addon_id, addon_name, dir
-                    );
+                if should_update {
+                    *selected_version = candidate_version;
                 }
             }
+
+            let inserts: Vec<InstalledAddon::ActiveModel> = detected_versions
+                .into_iter()
+                .map(|(addon_id, version)| InstalledAddon::ActiveModel {
+                    addon_id: ActiveValue::Set(addon_id),
+                    version: ActiveValue::Set(version),
+                    date: ActiveValue::Set(now.to_string()),
+                })
+                .collect();
+
             // 2. insert as installed, update checks will handle the rest
             if !inserts.is_empty() {
                 info!("Adding {} untracked addons", inserts.len());


### PR DESCRIPTION
## Summary

This PR fixes installed addon detection when a single ESOUI package maps to more than one local AddOns directory.

Some addon packages legitimately install multiple folders that refer to the same ESOUI addon ID. One example is **Ravalox' Quest Tracker**, which includes both:

* `RavaloxsQuestTracker`
* `Ravalox'QuestTracker`

The second folder is an obsolete marker folder included by the ESOUI package to overwrite the old addon folder name. It does not contain a normal addon manifest, but it is still listed as one of the package directories.

## Problem

During untracked addon detection, both local folders were matched to the same `addon_id`:

```text
addon_id=13 name="Ravalox' Quest Tracker" dir="Ravalox'QuestTracker"
addon_id=13 name="Ravalox' Quest Tracker" dir="RavaloxsQuestTracker"
```

The scanner then attempted to insert both matches as separate `installed_addon` rows. Since `installed_addon.addon_id` is unique, the scan failed with:

```text
UNIQUE constraint failed: installed_addon.addon_id
```

After that, the Installed tab showed no addons even though the AddOns folder was valid and addons had been detected.

## Changes

This PR includes two commits:

1. `chore: log duplicate installed addon directory matches`

   Adds diagnostic logging when multiple detected local directories map to the same `addon_id`. This makes the failure case visible before the database insert occurs.

2. `fix: handle multi-directory installed addon packages`

   Groups detected directory matches by `addon_id` before inserting installed addon records. When multiple folders map to the same addon package, they are treated as one installed package.

   This also improves detected version selection by preferring real manifest versions over fallback `"0"` values from obsolete or non-manifest folders.

## Verified behavior

Before the fix, the scan failed after detecting duplicate candidates:

```text
Duplicate installed-addon detection candidate for addon_id 13: 2 matches
  duplicate candidate addon_id=13 name="Ravalox' Quest Tracker" dir="Ravalox'QuestTracker"
  duplicate candidate addon_id=13 name="Ravalox' Quest Tracker" dir="RavaloxsQuestTracker"
UNIQUE constraint failed: installed_addon.addon_id
```

After the fix, the same package is treated as one installed addon package:

```text
Addon package 13 "Ravalox' Quest Tracker" matched multiple local directories; treating as one installed package with version "3.8.3.2"
  matched directory addon_id=13 name="Ravalox' Quest Tracker" dir="Ravalox'QuestTracker" version="0"
  matched directory addon_id=13 name="Ravalox' Quest Tracker" dir="RavaloxsQuestTracker" version="3.8.3.2"
Adding 168 untracked addon packages from 169 detected addon directory matches
Done getting addons!
```

The Installed tab now loads successfully and shows the detected addons.