### PR TITLE
Fix stale update status after batch updates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -277,18 +277,22 @@ impl EamApp {
 
         // update addons poll
         let mut updated_addons = vec![];
+
         for (addon_id, promise) in self.update_one.iter_mut() {
             promise.poll_recording(&self.service, &format!("Updating addon {addon_id}"));
             if promise.is_ready() {
                 updated_addons.push(addon_id.to_owned());
                 promise.handle();
-                addons_changed = true;
                 info!("Updated addon: {addon_id}");
             }
         }
+
         for addon_id in updated_addons.iter() {
             self.update_one.remove(addon_id);
         }
+
+        addons_changed =
+            addons_changed || (!updated_addons.is_empty() && self.update_one.is_empty());
 
         // install addons poll
         let mut installed_addons = vec![];


### PR DESCRIPTION
## Summary

This PR fixes an Installed tab refresh issue after running batch addon updates.

When multiple addons are updated through **Update All**, individual update tasks can finish at different times. The app previously treated each completed update as a generic addon change, which could refresh installed addon state while other update tasks were still running.

That partial refresh could leave stale **Update** buttons visible in the Installed tab even after the addons had successfully updated. Manually clicking **Check for Updates** afterward refreshed the list and showed the addons as current.

## Problem

`Update All` queues individual addon update promises through the same path used for single-addon updates.

Before this change, each completed update set the generic `addons_changed` flag:

```rust
addons_changed = true;
```

At the end of `poll()`, that triggered:

```rust
self.handle_addons_changed();
```

which reloads installed addon state.

With a small number of updates, this often behaved correctly. With a larger batch the Installed tab could be refreshed while the update queue was only partially complete. The tab could then be rebuilt from intermediate state, leaving addons displayed with stale **Update** buttons until the user manually checked for updates again.

## Changes

This PR tracks addon update completion separately from other addon changes.

Instead of refreshing installed addon state after any individual update completes, the app now:

1. Tracks whether any addon update promises completed during the current `poll()` pass.
2. Removes completed update promises from `update_one`.
3. Checks whether the update queue is empty.
4. Refreshes installed addon state only after the update queue has fully drained.

This avoids refreshing the Installed tab from partial batch-update state.

The refresh remains local-only. It uses the existing installed-addon refresh path and does not trigger another MMOUI file list/category request, TTC PriceTable update, or HarvestMap-Data update after the batch completes.

## Verified behavior

This was tested by manually installing old versions of two addons, removing/re-detecting, clicking **Check for Updates**, and then updating them through **Update All**.

The update queue now reports partial completion without refreshing installed state:

```text
Updated addon: 1360
Addon update completed; completed_this_tick=1, remaining=1, queue_finished=false
```

When the final update completes, the queue is marked finished and installed addon state is refreshed once:

```text
Updated addon: 1643
Addon update completed; completed_this_tick=1, remaining=0, queue_finished=true
Addon update queue finished; refreshing installed addon state
Getting installed addons
Checking for untracked addons
Getting installed addons
Done getting addons!
Checking for missing dependencies
```

No repeated MMOUI catalog refresh or optional data updater run was observed after the update queue drained.
