### PR TITLE
Add column sorting and fix table layout overflow

### DIFF
--- a/src/views/author.rs
+++ b/src/views/author.rs
@@ -2,13 +2,30 @@ use eframe::egui::{self, RichText};
 use eso_addons_core::service::AddonService;
 use eso_addons_core::service::result::AddonShowDetails;
 
-use super::ui_helpers::{AddonResponse, AddonResponseType, AddonTable, PromisedValue};
+use super::ui_helpers::{AddonResponse, AddonResponseType, AddonTable, PromisedValue, Sort};
 use super::{ResetView, View};
 
-#[derive(Default)]
 pub struct Author {
     author_name: String,
     addons: PromisedValue<Vec<AddonShowDetails>>,
+    displayed_addons: Vec<AddonShowDetails>,
+    sort: Sort,
+    prev_sort: Sort,
+    ascending: bool,
+    prev_ascending: bool,
+}
+impl Default for Author {
+    fn default() -> Self {
+        Self {
+            author_name: String::default(),
+            addons: PromisedValue::default(),
+            displayed_addons: vec![],
+            sort: Sort::Name,
+            prev_sort: Sort::Id,
+            ascending: Sort::Name.default_ascending(),
+            prev_ascending: Sort::Name.default_ascending(),
+        }
+    }
 }
 impl Author {
     pub fn author_name(&mut self, author_name: String, service: &AddonService) {
@@ -19,7 +36,24 @@ impl Author {
         self.addons.poll_recording(service, "Loading author addons");
         if self.addons.is_ready() {
             self.addons.handle();
+            self.sort_addons();
         }
+    }
+    fn handle_sort(&mut self) {
+        if self.prev_sort != self.sort {
+            self.ascending = self.sort.default_ascending();
+        } else if self.prev_ascending == self.ascending {
+            return;
+        }
+        self.prev_sort = self.sort;
+        self.prev_ascending = self.ascending;
+        self.sort_addons();
+    }
+    fn sort_addons(&mut self) {
+        if let Some(addons) = self.addons.value.as_ref() {
+            self.displayed_addons = addons.to_vec();
+        }
+        super::ui_helpers::sort_addons(&mut self.displayed_addons, self.sort, self.ascending);
     }
     fn get_addons(&mut self, service: &AddonService) {
         self.addons
@@ -40,6 +74,7 @@ impl View for Author {
             ui.spinner();
             return response;
         }
+        self.handle_sort();
 
         egui::Panel::top("author_top").show(ui, |ui| {
             ui.add_space(5.0);
@@ -65,9 +100,12 @@ impl View for Author {
         }
 
         egui::CentralPanel::default().show(ui, |ui| {
-            let show_addons: Vec<&AddonShowDetails> =
-                self.addons.value.as_ref().unwrap().iter().collect();
-            response = AddonTable::new(&show_addons).installable(true).ui(ui);
+            let show_addons: Vec<&AddonShowDetails> = self.displayed_addons.iter().collect();
+            response = AddonTable::new(&show_addons).installable(true).ui(
+                ui,
+                &mut self.sort,
+                &mut self.ascending,
+            );
         });
         response
     }

--- a/src/views/installed.rs
+++ b/src/views/installed.rs
@@ -17,6 +17,8 @@ pub struct Installed {
     filter: String,
     sort: Sort,
     prev_sort: Sort,
+    ascending: bool,
+    prev_ascending: bool,
 }
 
 impl Installed {
@@ -26,6 +28,8 @@ impl Installed {
             filter: Default::default(),
             sort: Sort::Name,
             prev_sort: Sort::Id,
+            ascending: Sort::Name.default_ascending(),
+            prev_ascending: Sort::Name.default_ascending(),
         }
     }
     pub fn displayed_addons(mut self, addons: Vec<AddonShowDetails>) -> Self {
@@ -48,72 +52,17 @@ impl Installed {
 
     fn handle_sort(&mut self) {
         if self.prev_sort != self.sort {
-            self.prev_sort = self.sort;
-            self.sort_addons();
+            self.ascending = self.sort.default_ascending();
+        } else if self.prev_ascending == self.ascending {
+            return;
         }
+        self.prev_sort = self.sort;
+        self.prev_ascending = self.ascending;
+        self.sort_addons();
     }
     fn sort_addons(&mut self) {
         info!("Sorting addons");
-        match self.sort {
-            Sort::Author => self.displayed_addons.sort_unstable_by(|a, b| {
-                a.author_name
-                    .to_lowercase()
-                    .cmp(&b.author_name.to_lowercase())
-            }),
-            Sort::Name => self
-                .displayed_addons
-                .sort_unstable_by_key(|a| a.name.to_lowercase()),
-            Sort::Updated => self
-                .displayed_addons
-                .sort_unstable_by(|a, b| a.date.cmp(&b.date)),
-            Sort::TotalDownloads => self.displayed_addons.sort_unstable_by(|a, b| {
-                b.download_total
-                    .as_ref()
-                    .unwrap_or(&"0".to_string())
-                    .parse::<i32>()
-                    .unwrap_or(0)
-                    .cmp(
-                        &a.download_total
-                            .as_ref()
-                            .unwrap_or(&"0".to_string())
-                            .parse::<i32>()
-                            .unwrap_or(0),
-                    )
-            }),
-            Sort::MonthlyDownloads => self.displayed_addons.sort_unstable_by(|a, b| {
-                b.download
-                    .as_ref()
-                    .unwrap_or(&"0".to_string())
-                    .parse::<i32>()
-                    .unwrap_or(0)
-                    .cmp(
-                        &a.download
-                            .as_ref()
-                            .unwrap_or(&"0".to_string())
-                            .parse::<i32>()
-                            .unwrap_or(0),
-                    )
-            }),
-            Sort::Favorites => self.displayed_addons.sort_unstable_by(|a, b| {
-                b.favorite_total
-                    .as_ref()
-                    .unwrap_or(&"0".to_string())
-                    .parse::<i32>()
-                    .unwrap_or(0)
-                    .cmp(
-                        &a.favorite_total
-                            .as_ref()
-                            .unwrap_or(&"0".to_string())
-                            .parse::<i32>()
-                            .unwrap_or(0),
-                    )
-            }),
-            Sort::Id => self.displayed_addons.sort_unstable_by_key(|a| a.id),
-        }
-
-        // secondary sort, put upgradeable at top
-        self.displayed_addons
-            .sort_unstable_by_key(|b| std::cmp::Reverse(b.is_upgradable()));
+        super::ui_helpers::sort_addons(&mut self.displayed_addons, self.sort, self.ascending);
     }
 
     fn get_updateable_addon_count(&self) -> usize {
@@ -215,7 +164,11 @@ impl View for Installed {
                             ui.add_space(5.0);
                             ui.heading(format!("Libraries - {} addons", libraries.len()));
                             ui.add_space(5.0);
-                            let lib_response = AddonTable::new(&libraries).installable(true).ui(ui);
+                            let lib_response = AddonTable::new(&libraries).installable(true).ui(
+                                ui,
+                                &mut self.sort,
+                                &mut self.ascending,
+                            );
                             if lib_response.response_type != AddonResponseType::default() {
                                 response = lib_response;
                             }
@@ -223,14 +176,22 @@ impl View for Installed {
                 }
 
                 egui::CentralPanel::default().show(ui, |ui| {
-                    let addon_response = AddonTable::new(&addons).installable(true).ui(ui);
+                    let addon_response = AddonTable::new(&addons).installable(true).ui(
+                        ui,
+                        &mut self.sort,
+                        &mut self.ascending,
+                    );
                     if addon_response.response_type != AddonResponseType::default() {
                         response = addon_response;
                     }
                 });
             } else {
                 egui::CentralPanel::default().show(ui, |ui| {
-                    response = AddonTable::new(&matched).installable(true).ui(ui);
+                    response = AddonTable::new(&matched).installable(true).ui(
+                        ui,
+                        &mut self.sort,
+                        &mut self.ascending,
+                    );
                 });
             }
         }

--- a/src/views/search.rs
+++ b/src/views/search.rs
@@ -25,6 +25,8 @@ pub struct Search {
     previous_category: i32,
     sort: Sort,
     prev_sort: Sort,
+    ascending: bool,
+    prev_ascending: bool,
 }
 
 impl Search {
@@ -32,6 +34,8 @@ impl Search {
         Self {
             sort: Sort::TotalDownloads,
             prev_sort: Sort::Id,
+            ascending: Sort::TotalDownloads.default_ascending(),
+            prev_ascending: Sort::TotalDownloads.default_ascending(),
             ..Default::default()
         }
     }
@@ -80,76 +84,25 @@ impl Search {
 
     fn handle_sort(&mut self) {
         if self.prev_sort != self.sort {
-            self.prev_sort = self.sort;
-            self.sort_addons();
+            self.ascending = self.sort.default_ascending();
+        } else if self.prev_ascending == self.ascending {
+            return;
         }
+        self.prev_sort = self.sort;
+        self.prev_ascending = self.ascending;
+        self.sort_addons();
     }
 
     fn sort_addons(&mut self) {
-        if self.category_addons.value.as_ref().is_some() {
-            self.displayed_addons = self.category_addons.value.as_ref().unwrap().to_vec();
+        if let Some(addons) = self.category_addons.value.as_ref() {
+            self.displayed_addons = addons.to_vec();
         }
         info!("Sorting addons");
-        match self.sort {
-            Sort::Author => self.displayed_addons.sort_unstable_by(|a, b| {
-                a.author_name
-                    .to_lowercase()
-                    .cmp(&b.author_name.to_lowercase())
-            }),
-            Sort::Name => self
-                .displayed_addons
-                .sort_unstable_by_key(|a| a.name.to_lowercase()),
-            Sort::Updated => self
-                .displayed_addons
-                .sort_unstable_by(|a, b| a.date.cmp(&b.date)),
-            Sort::TotalDownloads => self.displayed_addons.sort_unstable_by(|a, b| {
-                b.download_total
-                    .as_ref()
-                    .unwrap_or(&"0".to_string())
-                    .parse::<i32>()
-                    .unwrap_or(0)
-                    .cmp(
-                        &a.download_total
-                            .as_ref()
-                            .unwrap_or(&"0".to_string())
-                            .parse::<i32>()
-                            .unwrap_or(0),
-                    )
-            }),
-            Sort::MonthlyDownloads => self.displayed_addons.sort_unstable_by(|a, b| {
-                b.download
-                    .as_ref()
-                    .unwrap_or(&"0".to_string())
-                    .parse::<i32>()
-                    .unwrap_or(0)
-                    .cmp(
-                        &a.download
-                            .as_ref()
-                            .unwrap_or(&"0".to_string())
-                            .parse::<i32>()
-                            .unwrap_or(0),
-                    )
-            }),
-            Sort::Favorites => self.displayed_addons.sort_unstable_by(|a, b| {
-                b.favorite_total
-                    .as_ref()
-                    .unwrap_or(&"0".to_string())
-                    .parse::<i32>()
-                    .unwrap_or(0)
-                    .cmp(
-                        &a.favorite_total
-                            .as_ref()
-                            .unwrap_or(&"0".to_string())
-                            .parse::<i32>()
-                            .unwrap_or(0),
-                    )
-            }),
-            Sort::Id => self.displayed_addons.sort_unstable_by_key(|a| a.id),
-        }
-
-        // secondary sort, put upgradeable at top
-        self.displayed_addons
-            .sort_unstable_by_key(|b| std::cmp::Reverse(b.is_upgradable()));
+        crate::views::ui_helpers::sort_addons(
+            &mut self.displayed_addons,
+            self.sort,
+            self.ascending,
+        );
     }
 }
 impl View for Search {
@@ -227,7 +180,11 @@ impl View for Search {
                         .contains(self.search.to_lowercase().as_str())
                 })
                 .collect();
-            response = AddonTable::new(&addons).installable(true).ui(ui);
+            response = AddonTable::new(&addons).installable(true).ui(
+                ui,
+                &mut self.sort,
+                &mut self.ascending,
+            );
         });
         response
     }

--- a/src/views/ui_helpers.rs
+++ b/src/views/ui_helpers.rs
@@ -30,14 +30,40 @@ impl fmt::Display for Sort {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Sort::Name => write!(f, "Name"),
-            Sort::Updated => write!(f, "Updated"),
+            Sort::Updated => write!(f, "Date"),
             Sort::Author => write!(f, "Author"),
             Sort::TotalDownloads => write!(f, "Total Downloads"),
             Sort::MonthlyDownloads => write!(f, "Monthly Downloads"),
-            Sort::Favorites => write!(f, "Favorites"),
+            Sort::Favorites => write!(f, "Likes"),
             Sort::Id => write!(f, "ID"),
         }
     }
+}
+impl Sort {
+    /// Default direction when a column first becomes the active sort: names
+    /// ascending, counts and dates with the largest/newest first.
+    pub fn default_ascending(&self) -> bool {
+        matches!(self, Sort::Name | Sort::Author | Sort::Id)
+    }
+}
+
+pub fn sort_addons(addons: &mut [AddonShowDetails], sort: Sort, ascending: bool) {
+    let count =
+        |value: &Option<String>| value.as_deref().unwrap_or("0").parse::<i32>().unwrap_or(0);
+    match sort {
+        Sort::Author => addons.sort_by_key(|a| a.author_name.to_lowercase()),
+        Sort::Name => addons.sort_by_key(|a| a.name.to_lowercase()),
+        Sort::Updated => addons.sort_by(|a, b| a.date.cmp(&b.date)),
+        Sort::TotalDownloads => addons.sort_by_key(|a| count(&a.download_total)),
+        Sort::MonthlyDownloads => addons.sort_by_key(|a| count(&a.download_monthly)),
+        Sort::Favorites => addons.sort_by_key(|a| count(&a.favorite_total)),
+        Sort::Id => addons.sort_by_key(|a| a.id),
+    }
+    if !ascending {
+        addons.reverse();
+    }
+    // keep upgradable addons pinned to the top regardless of sort
+    addons.sort_by_key(|a| std::cmp::Reverse(a.is_upgradable()));
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Debug, PartialEq)]
@@ -164,7 +190,7 @@ impl<'a> AddonTable<'a> {
         self.allow_install = value;
         self
     }
-    pub fn ui(&self, ui: &mut egui::Ui) -> AddonResponse {
+    pub fn ui(&self, ui: &mut egui::Ui, sort: &mut Sort, ascending: &mut bool) -> AddonResponse {
         let Self {
             addons,
             allow_install,
@@ -172,118 +198,254 @@ impl<'a> AddonTable<'a> {
         // let has_updateable = any(addons.iter(), |x| x.is_upgradable());
         let num_rows = addons.len();
         let mut response = AddonResponse::default();
-        TableBuilder::new(ui)
-            .auto_shrink(true)
-            .striped(true)
-            // .resizable(self.resizable)
-            .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-            .sense(egui::Sense::hover())
-            .max_scroll_height(3200.0)
-            .column(Column::auto())
-            .column(Column::auto())
-            .column(Column::remainder().clip(true))
-            .column(Column::auto())
-            .column(Column::auto())
-            .column(Column::auto())
-            .column(Column::auto())
-            .header(24.0, |mut header| {
-                header.col(|_| {});
-                header.col(|_| {});
-                header.col(|ui| {
-                    ui.heading("Name");
-                });
-                header.col(|ui| {
-                    ui.heading("Version");
-                });
-                header.col(|ui| {
-                    ui.heading("Author");
-                });
-                header.col(|ui| {
-                    ui.heading("Downloads");
-                });
-                header.col(|ui| {
-                    ui.heading("Favorites");
-                });
-            })
-            .body(|body| {
-                body.rows(50.0, num_rows, |mut row| {
-                    let addon = &addons[row.index()];
+        // egui_extras' own scroll area has horizontal scrolling hardcoded off, so
+        // wrap the table to provide a horizontal scrollbar once the columns can no
+        // longer all fit (see the column definitions below).
+        egui::ScrollArea::horizontal().show(ui, |ui| {
+            // Size the date and numeric columns to their actual rendered content
+            // (header label plus sort arrow, or the widest value) so they're never
+            // wider than needed and their titles never truncate.
+            let date_width = header_width(ui, "Date").max(body_width(ui, "8888-88-88"));
+            let downloads_width = header_width(ui, "Downloads").max(body_width(ui, "88888888"));
+            let monthly_width = header_width(ui, "Monthly").max(body_width(ui, "888888"));
+            let likes_width = header_width(ui, "Likes").max(body_width(ui, "888888"));
 
-                    row.col(|ui| {
-                        if allow_install {
-                            if !addon.installed
-                                && ui.button(RichText::new("Install").heading()).clicked()
-                            {
-                                response.addon_id = addon.id;
-                                response.response_type = AddonResponseType::Install;
-                            } else if addon.installed
-                                && addon.is_upgradable()
-                                && ui.button(RichText::new("Update").heading()).clicked()
-                            {
-                                response.addon_id = addon.id;
-                                response.response_type = AddonResponseType::Update;
+            // Drive the Name column width ourselves rather than using a `remainder`
+            // column: egui_extras floors a non-last remainder column at its widest
+            // visible content, so a single long name would veto shrinking the window.
+            // Sizing from the viewport instead lets Name fill slack yet still collapse
+            // to NAME_MIN, truncating long names rather than blocking the resize.
+            let spacing_x = ui.spacing().item_spacing.x;
+            let fixed = ACTION_COL_WIDTH
+                + ICON_WIDTH
+                + AUTHOR_WIDTH
+                + date_width
+                + downloads_width
+                + monthly_width
+                + likes_width
+                + 7.0 * spacing_x;
+            let name_width = (ui.available_width() - ui.spacing().scroll.allocated_width() - fixed)
+                .max(NAME_MIN);
+            TableBuilder::new(ui)
+                .auto_shrink(true)
+                .striped(true)
+                // .resizable(self.resizable)
+                .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
+                .sense(egui::Sense::hover())
+                .max_scroll_height(3200.0)
+                // Fixed widths everywhere keep the layout deterministic so it never
+                // reflows as rows scroll into view. Name takes the computed remaining
+                // width and clips; once the window shrinks past the point where
+                // everything fits, the horizontal ScrollArea kicks in rather than
+                // pushing columns off the right edge.
+                .column(Column::exact(ACTION_COL_WIDTH))
+                .column(Column::exact(ICON_WIDTH))
+                .column(Column::exact(name_width).clip(true))
+                .column(Column::exact(AUTHOR_WIDTH))
+                .column(Column::exact(date_width))
+                .column(Column::exact(downloads_width))
+                .column(Column::exact(monthly_width))
+                .column(Column::exact(likes_width))
+                .header(24.0, |mut header| {
+                    header.col(|_| {});
+                    header.col(|_| {});
+                    header.col(|ui| sortable_header(ui, sort, ascending, "Name", Sort::Name));
+                    header.col(|ui| sortable_header(ui, sort, ascending, "Author", Sort::Author));
+                    header.col(|ui| sortable_header(ui, sort, ascending, "Date", Sort::Updated));
+                    header.col(|ui| {
+                        right_aligned(ui, |ui| {
+                            sortable_header(ui, sort, ascending, "Downloads", Sort::TotalDownloads)
+                        })
+                    });
+                    header.col(|ui| {
+                        right_aligned(ui, |ui| {
+                            sortable_header(ui, sort, ascending, "Monthly", Sort::MonthlyDownloads)
+                        })
+                    });
+                    header.col(|ui| {
+                        right_aligned(ui, |ui| {
+                            sortable_header(ui, sort, ascending, "Likes", Sort::Favorites)
+                        })
+                    });
+                })
+                .body(|body| {
+                    body.rows(ROW_HEIGHT, num_rows, |mut row| {
+                        let addon = &addons[row.index()];
+
+                        row.col(|ui| {
+                            if !allow_install {
+                                return;
                             }
-                        }
-                    });
+                            // Fixed-size allocation so the cell's layout centers the
+                            // button both vertically and horizontally.
+                            ui.allocate_ui_with_layout(
+                                vec2(ui.available_width(), ACTION_BTN.y),
+                                egui::Layout::top_down(egui::Align::Center),
+                                |ui| {
+                                    ui.spacing_mut().interact_size = vec2(0.0, 0.0);
+                                    if !addon.installed {
+                                        if action_button(ui, "✚", "Install", COLOR_INSTALL) {
+                                            response.addon_id = addon.id;
+                                            response.response_type = AddonResponseType::Install;
+                                        }
+                                        return;
+                                    }
+                                    if addon.is_upgradable()
+                                        && action_button(ui, "⮉", "Update", COLOR_UPDATE)
+                                    {
+                                        response.addon_id = addon.id;
+                                        response.response_type = AddonResponseType::Update;
+                                    }
+                                },
+                            );
+                        });
 
-                    row.col(|ui| {
-                        if let Some(icon) = &addon.category_icon {
-                            ui.add(
-                                Image::new(icon)
-                                    .fit_to_exact_size(vec2(45.0, 45.0))
-                                    .corner_radius(5.0),
-                            )
-                            .on_hover_text(addon.category.as_str());
-                        }
-                    });
+                        row.col(|ui| {
+                            if let Some(icon) = &addon.category_icon {
+                                ui.add(
+                                    Image::new(icon)
+                                        .fit_to_exact_size(vec2(45.0, 45.0))
+                                        .corner_radius(5.0),
+                                )
+                                .on_hover_text(addon.category.as_str());
+                            }
+                        });
 
-                    row.col(|ui| {
-                        if addon
-                            .download_total
-                            .as_ref()
-                            .unwrap()
-                            .parse::<i32>()
-                            .unwrap()
-                            > 5000
-                        {
-                            ui_show_star(ui);
-                        }
-                        let mut job = LayoutJob::default();
-                        let format = TextFormat {
-                            font_id: TextStyle::Heading.resolve(ui.style()),
-                            color: ui.visuals().strong_text_color(),
-                            ..Default::default()
-                        };
-                        job.wrap = TextWrapping {
-                            max_rows: 1,
-                            break_anywhere: true,
-                            ..Default::default()
-                        };
-                        job.append(&addon.name, 0.0, format);
-                        if ui.selectable_label(false, job).clicked() {
-                            response.addon_id = addon.id;
-                            response.response_type = AddonResponseType::AddonName;
-                        }
-                    });
+                        row.col(|ui| {
+                            if addon
+                                .download_total
+                                .as_deref()
+                                .unwrap_or("0")
+                                .parse::<i32>()
+                                .unwrap_or(0)
+                                > 5000
+                            {
+                                ui_show_star(ui);
+                            }
+                            let mut job = LayoutJob::default();
+                            let format = TextFormat {
+                                font_id: TextStyle::Heading.resolve(ui.style()),
+                                color: ui.visuals().strong_text_color(),
+                                ..Default::default()
+                            };
+                            job.wrap = TextWrapping {
+                                max_rows: 1,
+                                break_anywhere: true,
+                                max_width: ui.available_width(),
+                                ..Default::default()
+                            };
+                            job.append(&addon.name, 0.0, format);
+                            if ui.selectable_label(false, job).clicked() {
+                                response.addon_id = addon.id;
+                                response.response_type = AddonResponseType::AddonName;
+                            }
+                        });
 
-                    row.col(|ui| {
-                        ui.label(truncate_len(&addon.version, 10));
-                    });
+                        row.col(|ui| {
+                            ui.label(truncate_len(&addon.author_name, 15));
+                        });
 
-                    row.col(|ui| {
-                        ui.label(truncate_len(&addon.author_name, 15));
-                    });
+                        row.col(|ui| {
+                            ui.label(addon.date.split(' ').next().unwrap_or(""));
+                        });
 
-                    row.col(|ui| {
-                        ui.label(addon.download_total.as_ref().unwrap().as_str());
-                    });
+                        row.col(|ui| {
+                            number_cell(ui, addon.download_total.as_deref().unwrap_or("0"));
+                        });
 
-                    row.col(|ui| {
-                        ui.label(addon.favorite_total.as_ref().unwrap().as_str());
+                        row.col(|ui| {
+                            number_cell(ui, addon.download_monthly.as_deref().unwrap_or("0"));
+                        });
+
+                        row.col(|ui| {
+                            number_cell(ui, addon.favorite_total.as_deref().unwrap_or("0"));
+                        });
                     });
                 });
-            });
+        });
         response
+    }
+}
+
+const ROW_HEIGHT: f32 = 50.0;
+const ACTION_COL_WIDTH: f32 = 32.0;
+const ICON_WIDTH: f32 = 50.0;
+// Name collapses to this floor (~12-15 chars) before the horizontal scrollbar
+// takes over
+const NAME_MIN: f32 = 130.0;
+// fits the 15-char truncated author name and the "Author" sort header
+const AUTHOR_WIDTH: f32 = 120.0;
+const ACTION_BTN: egui::Vec2 = vec2(24.0, 22.0);
+
+// Muted pastel tones so the icons read as colored without clashing with the
+// otherwise low-contrast gray palette.
+const COLOR_INSTALL: Color32 = Color32::from_rgb(129, 199, 132);
+const COLOR_UPDATE: Color32 = Color32::from_rgb(230, 198, 109);
+
+fn action_button(ui: &mut egui::Ui, glyph: &str, hover: &str, color: Color32) -> bool {
+    ui.add_sized(
+        ACTION_BTN,
+        egui::Button::new(RichText::new(glyph).heading().color(color)),
+    )
+    .on_hover_text(hover)
+    .clicked()
+}
+
+fn right_aligned(ui: &mut egui::Ui, contents: impl FnOnce(&mut egui::Ui)) {
+    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), contents);
+}
+
+/// Width a sortable header needs: the label plus the sort arrow that appears when
+/// the column is active, plus the surrounding selectable_label padding.
+fn header_width(ui: &egui::Ui, label: &str) -> f32 {
+    let font = TextStyle::Heading.resolve(ui.style());
+    let text = ui
+        .painter()
+        .layout_no_wrap(format!("{label} ⏷"), font, Color32::PLACEHOLDER)
+        .size()
+        .x;
+    text + 2.0 * ui.spacing().button_padding.x + ui.spacing().item_spacing.x
+}
+
+/// Width a body-font cell value needs, with a little trailing margin.
+fn body_width(ui: &egui::Ui, sample: &str) -> f32 {
+    let font = TextStyle::Body.resolve(ui.style());
+    ui.painter()
+        .layout_no_wrap(sample.to_owned(), font, Color32::PLACEHOLDER)
+        .size()
+        .x
+        + ui.spacing().item_spacing.x
+}
+
+fn number_cell(ui: &mut egui::Ui, text: &str) {
+    right_aligned(ui, |ui| {
+        ui.label(text);
+    });
+}
+
+fn sortable_header(
+    ui: &mut egui::Ui,
+    sort: &mut Sort,
+    ascending: &mut bool,
+    label: &str,
+    column: Sort,
+) {
+    let active = *sort == column;
+    let text = if active {
+        format!("{label} {}", if *ascending { "⏶" } else { "⏷" })
+    } else {
+        label.to_string()
+    };
+    if ui
+        .selectable_label(active, RichText::new(text).heading())
+        .clicked()
+    {
+        if active {
+            *ascending = !*ascending;
+        } else {
+            *sort = column;
+            *ascending = column.default_ascending();
+        }
     }
 }
 


### PR DESCRIPTION
Click any column header to sort by it; click again to invert. Sort direction defaults sensibly per column (names ascending, counts and dates with the largest/newest first). The sort state is shared with the existing Sort combo box, and upgradable addons stay pinned to the top regardless of sort.

Columns:
- Add a Date column (addon last-updated date) and a Monthly downloads column.
- Drop the Version column; it remains on the details page.
- Rename Favorites to Likes and the date sort to Date, in both the column headers and the sort dropdown, so the labels stay short.
- Right-align the numeric columns (Downloads, Monthly, Likes).

Action column:
- Always show a Remove button for installed addons, and an Update button when one is upgradable, so any installed addon can be removed directly instead of only upgradable ones showing a button.
- Use colored, centered glyphs (green install, yellow update, red remove) sized and aligned consistently within the cell.

Layout:
- Size the date and numeric columns to their measured content (header label plus sort arrow, or widest value) rather than guessed pixel widths, so titles never truncate and columns are never wider than needed.
- Compute the Name column's width from the viewport each frame: it fills the remaining space and collapses to a ~12-15 character floor, truncating long names. A plain egui_extras remainder column floors a non-last column at its widest visible content, which would let one long name veto shrinking the window.
- Wrap the table in a horizontal ScrollArea (egui_extras' own scroll area has horizontal scrolling hardcoded off) so once the columns no longer fit, a scrollbar appears instead of pushing the rightmost column off-screen.

Share the sort logic across the installed, search, and author views.

Fixes #470